### PR TITLE
Promote latest frontend to staging (auth flows + POPIA export)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,14 @@ all other authenticated endpoints are under `/api/*` (use `buildApiEndpointUrl`)
   (`api.freework.co.za`) exists; then add a Cloudflare Pages prod deploy.
 
 Cloudflare Pages specifics:
+- **Direct Upload only — do NOT connect the Pages project's Git integration.**
+  We build in GitHub Actions (Node 24) and `wrangler pages deploy` the prebuilt
+  `dist/angular-app/browser`. CF's native Git-integration build is redundant and,
+  with no `.node-version`/`.nvmrc` in the repo, runs on CF's default (old) Node,
+  which Angular 20 + the npm 11 lockfile reject — so it fails on every branch and
+  posts a permanently-red **`Cloudflare Pages`** check (distinct from the green
+  GHA **`Deploy → Staging`** check). If you ever see that red check return, someone
+  re-connected the Git integration in the dashboard — disconnect it, don't "fix" it.
 - Secrets `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` live in the `staging`
   GitHub environment. The Pages project auto-creates on first deploy.
 - `public/_redirects` (`/* /index.html 200`) gives SPA deep-link routing — do NOT

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com https://ai-chatbot-backend-production-d810.up.railway.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.freework.co.za wss://api.freework.co.za https://api-staging.freework.co.za wss://api-staging.freework.co.za https://cloudflareinsights.com https://ai-chatbot-backend-production-d810.up.railway.app;
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.freework.co.za wss://api.freework.co.za https://api-staging.freework.co.za wss://api-staging.freework.co.za https://cloudflareinsights.com https://ai-chatbot-backend-production-d810.up.railway.app;
   X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Allow: /
+Disallow: /settings
+Disallow: /payments
+Disallow: /messages
+Disallow: /admin/
+Disallow: /profile/edit
+Disallow: /profile/setup
+
+Sitemap: https://freework.co.za/sitemap.xml

--- a/scripts/setup-github-backlog.sh
+++ b/scripts/setup-github-backlog.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# setup-github-backlog.sh  (freework-frontend)
+# -----------------------------------------------------------------------------
+# Creates the SINGLE "FreeWork Frontend Roadmap" backlog in GitHub:
+#   1. Priority / Area / Phase labels
+#   2. All roadmap issues, each labelled
+#   3. One GitHub Project (v2) board, with every issue added
+#
+# One board. No sprawl. Filter the board by label for any slice.
+#
+# PREREQUISITES (one-time):
+#   - GitHub CLI:                 https://cli.github.com
+#   - Auth with project scope:    gh auth login -s project,repo   (or: gh auth refresh -s project,repo)
+#
+# USAGE (run from anywhere):
+#   bash scripts/setup-github-backlog.sh
+#
+# Re-running creates DUPLICATE issues. Run once. (Label creation is idempotent.)
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+OWNER="TriNext-Innovations"
+REPO="TriNext-Innovations/freework-frontend"
+PROJECT_TITLE="FreeWork Frontend Roadmap"
+
+command -v gh >/dev/null 2>&1 || { echo "ERROR: GitHub CLI (gh) not installed. See https://cli.github.com"; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "ERROR: Not authenticated. Run: gh auth login -s project,repo"; exit 1; }
+
+echo "==> Creating labels (skips existing)…"
+mklabel () { gh label create "$1" --repo "$REPO" --color "$2" --description "$3" 2>/dev/null \
+  && echo "    + $1" || echo "    = $1 (exists)"; }
+
+mklabel "priority:need-to-have" "B00020" "Required to launch safely / compete"
+mklabel "priority:nice-to-have" "B26A00" "Strengthens UX soon after launch"
+mklabel "priority:have-if-time" "2E7D32" "Upside / later"
+mklabel "area:frontend"   "2E75B6" "Angular app code / UX"
+mklabel "area:testing"    "0E8A16" "Unit / E2E tests"
+mklabel "area:devops"     "5319E7" "Build / deploy / CI"
+mklabel "area:security"   "B00020" "Security / CSP / headers"
+mklabel "area:compliance" "6F42C1" "POPIA / legal UX"
+mklabel "area:marketing"  "D93F0B" "Growth / chatbot / analytics"
+mklabel "area:docs"       "555555" "Docs / repo hygiene"
+mklabel "phase:0-blocker"   "D73A4A" "Do before launch"
+mklabel "phase:1-hardening" "FBCA04" "Launch week +/-"
+mklabel "phase:later"       "C5DEF5" "Post-launch / future"
+
+echo "==> Creating issues…"
+CREATED_URLS=()
+mkissue () {
+  local title="$1" labels="$2" body="$3" url
+  url=$(gh issue create --repo "$REPO" --title "$title" --label "$labels" --body "$body")
+  echo "    + $title"
+  CREATED_URLS+=("$url")
+}
+
+# ---------------- PHASE 0 — BLOCKERS ----------------
+mkissue "Wire real backend services; remove/guard mock-service fallbacks before prod" \
+  "priority:need-to-have,area:frontend,phase:0-blocker" \
+  "job.service, application.service, messaging.service, payment.service and review.service all inject Mock*Service. Ensure prod builds call the real backend and that mock data can never leak into production. **Acceptance:** prod uses live API; mocks compiled out or behind a dev-only flag."
+
+mkissue "Fix API base URL config (dev vs prod /api mismatch)" \
+  "priority:need-to-have,area:frontend,phase:0-blocker" \
+  "environment.ts dev apiUrl is http://localhost:8080 (no /api) while environment.prod.ts is https://api.freework.co.za/api. This mismatch breaks integration. Centralise the base URL and make paths consistent. **Acceptance:** one source of truth; all services resolve the same way in dev and prod."
+
+mkissue "Align auth refresh flow with backend /auth/refresh" \
+  "priority:need-to-have,area:frontend,phase:0-blocker" \
+  "token.interceptor already calls authService.refreshToken() on 401, but the backend currently lacks /auth/refresh. Coordinate with the backend refresh+revocation work so logout and token expiry behave correctly. **Acceptance:** 401 -> refresh -> retry works against the real backend; clean logout."
+
+mkissue "Lock the deploy workflow to the main branch only" \
+  "priority:need-to-have,area:devops,phase:0-blocker" \
+  ".github/workflows/deploy.yml triggers on main AND feature branches (feature/api-live-test, feature/404-not-found), publishing to the live freework.co.za domain. Restrict production deploys to main; use previews for branches. **Acceptance:** only main deploys to production."
+
+mkissue "Reconcile and clean repo docs + hygiene" \
+  "priority:need-to-have,area:docs,phase:0-blocker" \
+  "DEPLOYMENT_READY.md describes a '404-only' placeholder that no longer matches the live routes; several root markdown files are 0 bytes; .DS_Store is committed. Update/remove stale docs, delete empty files, add .DS_Store to .gitignore. **Acceptance:** docs match reality; no junk tracked."
+
+mkissue "Align payment UI with backend providers (PayFast/PayPal vs Stripe)" \
+  "priority:need-to-have,area:frontend,phase:0-blocker" \
+  "There is a stripe-payment component, but the backend implements PayFast (ZAR) + PayPal. Implement the correct provider UI and remove or gate the unused one. **Acceptance:** checkout uses the live provider(s); no dead Stripe path."
+
+# ---------------- PHASE 1 — HARDENING ----------------
+mkissue "Establish real test coverage (auth, payments, core services) + CI gate" \
+  "priority:need-to-have,area:testing,phase:1-hardening" \
+  "Only 1 .spec.ts exists across 42 components. Add meaningful unit tests for auth.service/guard/token.interceptor, payment + escrow flows, and core data services; run karma coverage in CI with a threshold. **Acceptance:** coverage gate enforced; critical paths tested."
+
+mkissue "Add frontend error tracking (Sentry browser SDK)" \
+  "priority:need-to-have,area:frontend,phase:1-hardening" \
+  "No client-side error visibility. Add Sentry (or equivalent) with release + source maps. **Acceptance:** runtime errors reported with stack traces."
+
+mkissue "Security headers / CSP review" \
+  "priority:need-to-have,area:security,phase:1-hardening" \
+  "Tighten the CSP (index.html meta + Cloudflare public/_headers) to only required origins, including api.freework.co.za and the WebSocket (wss) origin. **Acceptance:** CSP passes with no console violations; no wildcard sources."
+
+mkissue "Verify POPIA UX wired end-to-end" \
+  "priority:need-to-have,area:compliance,phase:1-hardening" \
+  "Legal components exist (cookie-consent-banner, popia-request, reconsent, unsubscribe, delete-account, popia-admin). Confirm each is reachable, functional, and backed by an API. **Acceptance:** a user can consent, request data, withdraw, and delete their account."
+
+mkissue "Loading / empty / error states across all flows" \
+  "priority:nice-to-have,area:frontend,phase:1-hardening" \
+  "Add consistent loading skeletons, empty states, and error handling for jobs, messaging, payments, profile and reviews. **Acceptance:** no blank screens on slow/failed requests."
+
+mkissue "Performance: lazy-load routes, bundle budgets, review particles.js" \
+  "priority:nice-to-have,area:frontend,phase:1-hardening" \
+  "Lazy-load feature routes, set Angular bundle budgets, and assess the cost of particles.js. **Acceptance:** fast first load on mobile; budgets enforced in CI."
+
+mkissue "Accessibility audit (WCAG AA basics)" \
+  "priority:nice-to-have,area:frontend,phase:1-hardening" \
+  "Audit colour contrast, focus order, labels and keyboard nav (Angular Material helps). **Acceptance:** core flows pass an automated a11y check."
+
+mkissue "E2E tests for the core loop (Playwright)" \
+  "priority:nice-to-have,area:testing,phase:1-hardening" \
+  "Cover register -> verify -> post/apply -> message -> pay -> review against a staging backend. **Acceptance:** green E2E run in CI."
+
+# ---------------- LATER ----------------
+mkissue "Integrate the marketing chatbot (Zoho SalesIQ / Zobot)" \
+  "priority:nice-to-have,area:marketing,phase:later" \
+  "An empty chatbotApiKey already exists in environment config. Embed the SalesIQ/Zobot widget and wire onboarding/help flows. **Acceptance:** bot live on the site; leads flow to CRM via Zoho Flow."
+
+mkissue "SEO / meta / Open Graph for public job & profile pages" \
+  "priority:nice-to-have,area:frontend,phase:later" \
+  "Add titles, meta descriptions and OG tags; ensure public pages are crawlable for organic acquisition. **Acceptance:** rich previews + indexable public pages."
+
+mkissue "Privacy-friendly analytics + funnel events to Zoho" \
+  "priority:nice-to-have,area:marketing,phase:later" \
+  "Track signup/post/apply/hire funnel events (POPIA-compliant) and feed Zoho journeys. **Acceptance:** funnel visible; events trigger lifecycle automation."
+
+mkissue "PWA / offline support" \
+  "priority:have-if-time,area:frontend,phase:later" \
+  "Add a service worker + installable PWA for mobile reach. **Acceptance:** installable; core pages work offline."
+
+mkissue "i18n scaffolding for pan-African expansion" \
+  "priority:have-if-time,area:frontend,phase:later" \
+  "Externalise strings and add locale support ahead of multi-market growth. **Acceptance:** at least one additional locale buildable."
+
+mkissue "Storybook component library + visual regression" \
+  "priority:have-if-time,area:frontend,phase:later" \
+  "Document shared components and add visual regression tests. **Acceptance:** Storybook published; snapshots gating UI changes."
+
+echo "==> Creating the single Project board: \"$PROJECT_TITLE\"…"
+if gh project create --owner "$OWNER" --title "$PROJECT_TITLE" >/dev/null 2>&1; then
+  PROJ_NUM=$(gh project list --owner "$OWNER" --format json --jq ".projects[] | select(.title==\"$PROJECT_TITLE\") | .number" | head -n1)
+  echo "    Project #$PROJ_NUM created. Adding ${#CREATED_URLS[@]} issues…"
+  for u in "${CREATED_URLS[@]}"; do
+    gh project item-add "$PROJ_NUM" --owner "$OWNER" --url "$u" >/dev/null 2>&1 && echo "    + added $u" || echo "    ! could not add $u"
+  done
+  echo ""; echo "DONE. Open the board and group/filter by label (Priority / Area / Phase)."
+else
+  echo ""; echo "NOTE: Could not auto-create the Project (likely missing 'project' scope)."
+  echo "Run: gh auth refresh -s project   then create it manually and 'Add items' filtered by label."
+  echo "All issues were created and labelled, ready to add."
+fi

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,29 +1,65 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { DOCUMENT } from '@angular/common';
+import { BehaviorSubject, of } from 'rxjs';
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { AppComponent } from './app.component';
+import { AuthService } from './auth/auth.service';
+import { ThemeService } from './theme.service';
+import { SubscriptionService } from './subscription/subscription.service';
 
 describe('AppComponent', () => {
+  let authService: jasmine.SpyObj<AuthService>;
+
   beforeEach(async () => {
+    const userSubject = new BehaviorSubject(null);
+    authService = jasmine.createSpyObj('AuthService', ['logout'], {
+      currentUser$: userSubject.asObservable()
+    });
+
+    const themeServiceSpy = jasmine.createSpyObj('ThemeService', ['toggleTheme'], {
+      theme$: of('dark')
+    });
+
+    const subscriptionServiceSpy = jasmine.createSpyObj('SubscriptionService', [
+      'loadSubscription', 'clearSubscription'
+    ], { subscription$: of(null) });
+    subscriptionServiceSpy.loadSubscription.and.returnValue(of(null));
+    subscriptionServiceSpy.clearSubscription.and.stub();
+
+    const bpSpy = jasmine.createSpyObj('BreakpointObserver', ['observe']);
+    bpSpy.observe.and.returnValue(of({ matches: true } as BreakpointState));
+
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authService },
+        { provide: ThemeService, useValue: themeServiceSpy },
+        { provide: SubscriptionService, useValue: subscriptionServiceSpy },
+        { provide: BreakpointObserver, useValue: bpSpy },
+        { provide: DOCUMENT, useValue: document }
+      ]
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it(`should have the 'angular-app' title`, () => {
+  it('should have the Freework title', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('angular-app');
+    expect(fixture.componentInstance.title).toBe('Freework');
   });
 
-  it('should render title', () => {
+  it('should call authService.logout() on logout()', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, angular-app');
+    fixture.componentInstance.logout();
+    expect(authService.logout).toHaveBeenCalled();
   });
 });

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -26,6 +26,14 @@ export const routes: Routes = [
     path: 'auth/verified',
     loadComponent: () => import('./auth/email-verified/email-verified.component').then(m => m.EmailVerifiedComponent)
   },
+  {
+    path: 'forgot-password',
+    loadComponent: () => import('./auth/forgot-password/forgot-password.component').then(m => m.ForgotPasswordComponent)
+  },
+  {
+    path: 'auth/reset-password',
+    loadComponent: () => import('./auth/reset-password/reset-password.component').then(m => m.ResetPasswordComponent)
+  },
 
   // Job routes
   {
@@ -104,7 +112,7 @@ export const routes: Routes = [
   },
   {
     path: 'payments/create/:jobId',
-    loadComponent: () => import('./payments/stripe-payment/stripe-payment.component').then(m => m.StripePaymentComponent),
+    loadComponent: () => import('./payments/stripe-payment/stripe-payment.component').then(m => m.CheckoutPaymentComponent),
     canActivate: [authGuard, roleGuard(['CUSTOMER'])]
   },
   {

--- a/src/app/auth/auth.guard.spec.ts
+++ b/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { authGuard, guestGuard, roleGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
+function makeState(url: string): RouterStateSnapshot {
+  return { url } as RouterStateSnapshot;
+}
+
+const emptyRoute = {} as ActivatedRouteSnapshot;
+
+describe('Auth Guards', () => {
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'getCurrentUser']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router }
+      ]
+    });
+  });
+
+  describe('authGuard', () => {
+    it('returns true when user is logged in', () => {
+      authService.isLoggedIn.and.returnValue(true);
+      const result = TestBed.runInInjectionContext(() => authGuard(emptyRoute, makeState('/dashboard')));
+      expect(result).toBeTrue();
+    });
+
+    it('redirects to /login with returnUrl when not logged in', () => {
+      authService.isLoggedIn.and.returnValue(false);
+      const result = TestBed.runInInjectionContext(() => authGuard(emptyRoute, makeState('/dashboard')));
+      expect(result).toBeFalse();
+      expect(router.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { returnUrl: '/dashboard' } });
+    });
+  });
+
+  describe('guestGuard', () => {
+    it('allows access when user is NOT logged in', () => {
+      authService.isLoggedIn.and.returnValue(false);
+      const result = TestBed.runInInjectionContext(() => guestGuard(emptyRoute, makeState('/login')));
+      expect(result).toBeTrue();
+    });
+
+    it('redirects to / when user is already logged in', () => {
+      authService.isLoggedIn.and.returnValue(true);
+      const result = TestBed.runInInjectionContext(() => guestGuard(emptyRoute, makeState('/login')));
+      expect(result).toBeFalse();
+      expect(router.navigate).toHaveBeenCalledWith(['/']);
+    });
+  });
+
+  describe('roleGuard', () => {
+    it('allows access for a user with the required role', () => {
+      authService.isLoggedIn.and.returnValue(true);
+      authService.getCurrentUser.and.returnValue({ role: 'CUSTOMER' } as never);
+      const result = TestBed.runInInjectionContext(() => roleGuard(['CUSTOMER'])(emptyRoute, makeState('/my-jobs')));
+      expect(result).toBeTrue();
+    });
+
+    it('denies access and redirects to / for wrong role', () => {
+      authService.isLoggedIn.and.returnValue(true);
+      authService.getCurrentUser.and.returnValue({ role: 'FREELANCER' } as never);
+      const result = TestBed.runInInjectionContext(() => roleGuard(['CUSTOMER'])(emptyRoute, makeState('/my-jobs')));
+      expect(result).toBeFalse();
+      expect(router.navigate).toHaveBeenCalledWith(['/']);
+    });
+
+    it('redirects to /login when not authenticated', () => {
+      authService.isLoggedIn.and.returnValue(false);
+      const result = TestBed.runInInjectionContext(() => roleGuard(['ADMIN'])(emptyRoute, makeState('/admin')));
+      expect(result).toBeFalse();
+      expect(router.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { returnUrl: '/admin' } });
+    });
+
+    it('allows ADMIN when ADMIN is in allowed roles', () => {
+      authService.isLoggedIn.and.returnValue(true);
+      authService.getCurrentUser.and.returnValue({ role: 'ADMIN' } as never);
+      const result = TestBed.runInInjectionContext(() => roleGuard(['CUSTOMER', 'ADMIN'])(emptyRoute, makeState('/admin')));
+      expect(result).toBeTrue();
+    });
+  });
+});

--- a/src/app/auth/auth.service.spec.ts
+++ b/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,157 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { AuthService } from './auth.service';
+import { buildApiUrl, buildApiEndpointUrl } from '../api.config';
+
+function makeJwt(payload: object): string {
+  const enc = (obj: object) => btoa(JSON.stringify(obj)).replace(/=/g, '');
+  return `${enc({ alg: 'HS256' })}.${enc({ exp: Math.floor(Date.now() / 1000) + 3600, ...payload })}.sig`;
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  const AUTH_URL = buildApiUrl('/auth');
+  const PROFILE_URL = buildApiEndpointUrl('/profile');
+
+  const accessToken = makeJwt({ sub: '1', email: 'test@example.com', role: 'FREELANCER', firstName: 'Test', lastName: 'User' });
+  const refreshToken = makeJwt({ sub: '1', type: 'refresh' });
+
+  const mockUser = {
+    id: '1', email: 'test@example.com', firstName: 'Test', lastName: 'User',
+    role: 'FREELANCER' as const, createdAt: '2024-01-01T00:00:00Z', profileCompleted: true
+  };
+
+  const mockAuthResponse = { accessToken, refreshToken, tokenType: 'Bearer', expiresIn: 3600, user: mockUser };
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([])
+      ]
+    });
+
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+    httpMock.match(() => true); // drain any constructor-time requests
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('login()', () => {
+    it('stores tokens and emits user on success', () => {
+      let result = false;
+      service.login({ email: 'test@example.com', password: 'Password1!' }).subscribe(() => { result = true; });
+
+      httpMock.expectOne(`${AUTH_URL}/login`).flush(mockAuthResponse);
+      httpMock.expectOne(PROFILE_URL).flush(mockUser); // fetchUserProfile after login
+
+      expect(result).toBeTrue();
+      expect(service.getAccessToken()).toBe(accessToken);
+    });
+
+    it('propagates error on 401', () => {
+      let errored = false;
+      service.login({ email: 'x@x.com', password: 'wrong' }).subscribe({ error: () => { errored = true; } });
+
+      httpMock.expectOne(`${AUTH_URL}/login`).flush({ message: 'Invalid' }, { status: 401, statusText: 'Unauthorized' });
+
+      expect(errored).toBeTrue();
+    });
+  });
+
+  describe('register()', () => {
+    it('POSTs to /register and completes', () => {
+      let done = false;
+      service.register({ fullName: 'A B', email: 'a@b.com', password: 'Password1!', role: 'FREELANCER' })
+        .subscribe(() => { done = true; });
+
+      const req = httpMock.expectOne(`${AUTH_URL}/register`);
+      expect(req.request.method).toBe('POST');
+      req.flush({ message: 'Registration successful' }, { status: 202, statusText: 'Accepted' });
+
+      expect(done).toBeTrue();
+    });
+  });
+
+  describe('logout()', () => {
+    it('clears tokens and navigates to /login', () => {
+      service['safeLocalStorageSet']('freework_access_token', accessToken);
+      service['safeLocalStorageSet']('freework_refresh_token', refreshToken);
+
+      service.logout();
+
+      httpMock.expectOne(`${AUTH_URL}/logout`).flush({ message: 'ok' });
+
+      expect(service.getAccessToken()).toBeNull();
+      expect(service.currentUserValue).toBeNull();
+    });
+  });
+
+  describe('forgotPassword()', () => {
+    it('POSTs email and returns message', () => {
+      let msg = '';
+      service.forgotPassword('test@example.com').subscribe(r => { msg = r.message; });
+
+      const req = httpMock.expectOne(`${AUTH_URL}/forgot-password`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ email: 'test@example.com' });
+      req.flush({ message: 'If that email is registered, a password reset link has been sent.' });
+
+      expect(msg).toContain('password reset link');
+    });
+  });
+
+  describe('resetPassword()', () => {
+    it('POSTs token and newPassword', () => {
+      let msg = '';
+      service.resetPassword('uuid-token', 'NewPass1!').subscribe(r => { msg = r.message; });
+
+      const req = httpMock.expectOne(`${AUTH_URL}/reset-password`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ token: 'uuid-token', newPassword: 'NewPass1!' });
+      req.flush({ message: 'Password reset successfully.' });
+
+      expect(msg).toContain('Password reset successfully');
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('returns false when localStorage has no token', () => {
+      expect(service.isAuthenticated).toBeFalse();
+    });
+
+    it('returns true when a non-expired token is stored', () => {
+      localStorage.setItem('freework_access_token', accessToken);
+      expect(service.isAuthenticated).toBeTrue();
+    });
+  });
+
+  describe('resendVerification()', () => {
+    it('POSTs email to /resend-verification', () => {
+      let done = false;
+      service.resendVerification('test@example.com').subscribe(() => { done = true; });
+
+      const req = httpMock.expectOne(`${AUTH_URL}/resend-verification`);
+      expect(req.request.method).toBe('POST');
+      req.flush({ message: 'Sent' });
+
+      expect(done).toBeTrue();
+    });
+  });
+});

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -116,6 +116,16 @@ export class AuthService {
       .pipe(catchError((error: HttpErrorResponse) => throwError(() => error)));
   }
 
+  forgotPassword(email: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${this.API_URL}/forgot-password`, { email })
+      .pipe(catchError((error: HttpErrorResponse) => throwError(() => error)));
+  }
+
+  resetPassword(token: string, newPassword: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${this.API_URL}/reset-password`, { token, newPassword })
+      .pipe(catchError((error: HttpErrorResponse) => throwError(() => error)));
+  }
+
   /**
    * Exchange the one-time code (from the ?code= redirect after email verification)
    * for a JWT. The code is single-use and expires after 5 minutes.

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -111,6 +111,11 @@ export class AuthService {
       );
   }
 
+  resendVerification(email: string): Observable<unknown> {
+    return this.http.post<unknown>(`${this.API_URL}/resend-verification`, { email })
+      .pipe(catchError((error: HttpErrorResponse) => throwError(() => error)));
+  }
+
   /**
    * Exchange the one-time code (from the ?code= redirect after email verification)
    * for a JWT. The code is single-use and expires after 5 minutes.

--- a/src/app/auth/email-verified/email-verified.component.ts
+++ b/src/app/auth/email-verified/email-verified.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AuthService } from '../auth.service';
 
@@ -27,7 +30,10 @@ import { AuthService } from '../auth.service';
     MatCardModule,
     MatButtonModule,
     MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
     MatProgressSpinnerModule,
+    FormsModule,
     RouterLink
   ],
   template: `
@@ -47,9 +53,23 @@ import { AuthService } from '../auth.service';
             <mat-icon class="error-icon">error</mat-icon>
             <h2>Verification Failed</h2>
             <p>{{ errorMessage }}</p>
-            <div class="actions">
-              <a mat-raised-button color="primary" routerLink="/login">Sign In</a>
-              <a mat-stroked-button routerLink="/register">Register Again</a>
+            @if (!resendSent) {
+              <div class="resend-form">
+                <mat-form-field appearance="outline" style="width:100%">
+                  <mat-label>Your email address</mat-label>
+                  <input matInput type="email" [(ngModel)]="resendEmail" placeholder="you@example.com">
+                </mat-form-field>
+                <button mat-raised-button color="primary" [disabled]="resendLoading || !resendEmail" (click)="resend()">
+                  @if (resendLoading) { <mat-spinner diameter="18" style="display:inline-block;margin-right:8px"></mat-spinner> }
+                  Resend verification email
+                </button>
+              </div>
+            }
+            @if (resendSent) {
+              <p class="resend-ok"><mat-icon>check_circle</mat-icon> Verification email sent — check your inbox.</p>
+            }
+            <div class="actions" style="margin-top:1rem">
+              <a mat-stroked-button routerLink="/login">Sign In</a>
             </div>
           }
         </mat-card-content>
@@ -75,12 +95,26 @@ import { AuthService } from '../auth.service';
     .error-icon  { font-size: 4rem; width: 4rem; height: 4rem; color: #f44336; }
     h2 { margin: 0.5rem 0; }
     .actions { display: flex; gap: 1rem; justify-content: center; margin-top: 1.5rem; flex-wrap: wrap; }
+    .resend-form { width: 100%; margin-top: 1.5rem; display: flex; flex-direction: column; gap: 0.75rem; align-items: center; }
+    .resend-ok { display: flex; align-items: center; gap: 0.5rem; color: #2BB88A; font-weight: 600; margin-top: 1rem; }
+    .resend-ok mat-icon { font-size: 1.25rem; width: 1.25rem; height: 1.25rem; }
   `]
 })
 export class EmailVerifiedComponent implements OnInit {
   loading = true;
   success = false;
-  errorMessage = 'The verification link is invalid or has expired. Please register again or request a new verification email.';
+  errorMessage = 'The verification link is invalid or has expired. Enter your email below to request a new one.';
+  resendEmail = '';
+  resendLoading = false;
+  resendSent = false;
+
+  resend(): void {
+    this.resendLoading = true;
+    this.authService.resendVerification(this.resendEmail).subscribe({
+      next: () => { this.resendLoading = false; this.resendSent = true; },
+      error: () => { this.resendLoading = false; }
+    });
+  }
 
   constructor(
     private route: ActivatedRoute,

--- a/src/app/auth/forgot-password/forgot-password.component.html
+++ b/src/app/auth/forgot-password/forgot-password.component.html
@@ -1,0 +1,64 @@
+<div class="fp-container">
+  <mat-card class="fp-card">
+
+    <mat-card-header>
+      <div class="brand-header">
+        <div class="brand-logo">
+          <svg viewBox="0 0 64 52" width="40" height="32" xmlns="http://www.w3.org/2000/svg">
+            <path d="M2 13 C14 13 20 29 32 29 C44 29 50 13 62 13" stroke="#2BB88A" stroke-width="7" fill="none" stroke-linecap="round"/>
+            <path d="M2 39 C14 39 20 23 32 23 C44 23 50 39 62 39" stroke="#2BB88A" stroke-width="7" fill="none" stroke-linecap="round" opacity="0.5"/>
+          </svg>
+          <span class="brand-wordmark"><strong>free</strong>work</span>
+        </div>
+        @if (submitted) {
+          <mat-card-title>Check your inbox</mat-card-title>
+          <mat-card-subtitle>We'll send a reset link if that address is registered</mat-card-subtitle>
+        } @else {
+          <mat-card-title>Reset your password</mat-card-title>
+          <mat-card-subtitle>Enter your email and we'll send you a link</mat-card-subtitle>
+        }
+      </div>
+    </mat-card-header>
+
+    <mat-card-content>
+      @if (submitted) {
+        <div class="confirmation">
+          <div class="confirmation-icon">
+            <mat-icon>mark_email_unread</mat-icon>
+          </div>
+          <p>
+            If <strong>{{ form.value.email }}</strong> is registered, you'll receive a password reset link
+            shortly. Check your spam folder if you don't see it within a few minutes.
+          </p>
+        </div>
+      } @else {
+        <form [formGroup]="form" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Email address</mat-label>
+            <input matInput type="email" formControlName="email" placeholder="your@email.com" autocomplete="email">
+            <mat-icon matPrefix>email</mat-icon>
+            @if (form.get('email')?.hasError('required') && form.get('email')?.touched) {
+              <mat-error>Email is required</mat-error>
+            } @else if (form.get('email')?.hasError('email') && form.get('email')?.touched) {
+              <mat-error>Please enter a valid email</mat-error>
+            }
+          </mat-form-field>
+
+          <button mat-raised-button color="primary" type="submit" class="full-width submit-btn" [disabled]="loading">
+            @if (loading) {
+              <mat-spinner diameter="20"></mat-spinner>
+              Sending...
+            } @else {
+              Send reset link
+            }
+          </button>
+        </form>
+      }
+
+      <div class="back-link">
+        <a routerLink="/login">← Back to sign in</a>
+      </div>
+    </mat-card-content>
+
+  </mat-card>
+</div>

--- a/src/app/auth/forgot-password/forgot-password.component.scss
+++ b/src/app/auth/forgot-password/forgot-password.component.scss
@@ -1,0 +1,214 @@
+:host {
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.fp-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100%;
+  padding: var(--spacing-xl);
+  background: url('/assets/Login_page_dark_new.png') center center / cover no-repeat fixed;
+
+  :host-context([data-theme="light"]) & {
+    background: url('/assets/Login_page_light_new.png') center center / cover no-repeat fixed;
+  }
+}
+
+.fp-card {
+  width: 420px;
+  max-width: calc(100vw - 2 * var(--spacing-xl));
+  box-sizing: border-box;
+  background: rgba(13, 31, 26, 0.55) !important;
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border-radius: var(--radius-xl) !important;
+  border: 1px solid rgba(43, 184, 138, 0.20) !important;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(43, 184, 138, 0.08) !important;
+
+  :host-context([data-theme="light"]) & {
+    background: rgba(255, 255, 255, 0.65) !important;
+    border: 1px solid rgba(43, 184, 138, 0.20) !important;
+    box-shadow: 0 8px 40px rgba(26, 141, 111, 0.12), 0 0 0 1px rgba(43, 184, 138, 0.10) !important;
+  }
+
+  .mdc-card, .mat-mdc-card-content {
+    border-radius: var(--radius-xl) !important;
+    background: transparent !important;
+  }
+}
+
+mat-card-header {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-2xl) var(--spacing-2xl) var(--spacing-xl);
+  text-align: center;
+}
+
+.brand-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+  width: 100%;
+}
+
+.brand-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: var(--spacing-xs);
+}
+
+.brand-wordmark {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 1.375rem;
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  color: rgba(255, 255, 255, 0.55);
+
+  strong {
+    font-weight: 700;
+    color: #ffffff;
+  }
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-secondary);
+    strong { color: var(--color-text-primary); }
+  }
+}
+
+mat-card-title {
+  font-family: 'Bricolage Grotesque', sans-serif !important;
+  font-size: 1.625rem !important;
+  font-weight: 700 !important;
+  margin-bottom: var(--spacing-xs) !important;
+  color: #ffffff !important;
+  letter-spacing: -0.025em !important;
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-primary) !important;
+  }
+}
+
+mat-card-subtitle {
+  font-size: 14px !important;
+  color: rgba(255, 255, 255, 0.65) !important;
+  font-weight: 400 !important;
+  line-height: 1.5 !important;
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-secondary) !important;
+  }
+}
+
+mat-card-content,
+::ng-deep .mat-mdc-card-content {
+  padding: 0 var(--spacing-2xl) var(--spacing-xl) !important;
+}
+
+.full-width { width: 100%; }
+
+mat-form-field { width: 100%; }
+
+.submit-btn {
+  width: 100%;
+  height: 44px;
+  font-size: 15px;
+  font-weight: 600;
+  margin-top: var(--spacing-xs);
+  background-color: var(--color-accent-600) !important;
+  color: white !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: none !important;
+  transition: all var(--transition-fast) !important;
+
+  &:hover:not([disabled]) {
+    background-color: var(--color-accent-700) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(26, 141, 111, 0.35) !important;
+  }
+
+  mat-spinner { display: inline-block; margin-right: var(--spacing-sm); }
+}
+
+.confirmation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--spacing-xl) 0 var(--spacing-md);
+  gap: var(--spacing-md);
+}
+
+.confirmation-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: rgba(43, 184, 138, 0.12);
+  border: 1px solid rgba(43, 184, 138, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 2rem;
+    width: 2rem;
+    height: 2rem;
+    color: #2BB88A;
+  }
+}
+
+.confirmation p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.6;
+
+  strong { color: #ffffff; }
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-secondary);
+    strong { color: var(--color-text-primary); }
+  }
+}
+
+.back-link {
+  text-align: center;
+  padding-top: var(--spacing-lg);
+
+  a {
+    color: #2BB88A;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: color var(--transition-fast);
+    &:hover { color: #1A8D6F; }
+  }
+}
+
+@media (max-width: 600px) {
+  .fp-container {
+    align-items: flex-start;
+    padding: var(--spacing-md);
+  }
+
+  .fp-card {
+    width: 100%;
+    max-width: calc(100vw - 2 * var(--spacing-md));
+  }
+
+  mat-card-header {
+    padding: var(--spacing-xl) var(--spacing-md) var(--spacing-md) !important;
+  }
+
+  mat-card-title { font-size: 1.375rem !important; }
+
+  mat-card-content,
+  ::ng-deep .mat-mdc-card-content {
+    padding: 0 var(--spacing-md) var(--spacing-md) !important;
+  }
+}

--- a/src/app/auth/forgot-password/forgot-password.component.ts
+++ b/src/app/auth/forgot-password/forgot-password.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-forgot-password',
+  imports: [
+    ReactiveFormsModule,
+    RouterLink,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './forgot-password.component.html',
+  styleUrl: './forgot-password.component.scss'
+})
+export class ForgotPasswordComponent {
+  form: FormGroup;
+  loading = false;
+  submitted = false;
+
+  constructor(private fb: FormBuilder, private authService: AuthService) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]]
+    });
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.loading) return;
+    this.loading = true;
+    this.authService.forgotPassword(this.form.value.email as string).subscribe({
+      next: () => { this.submitted = true; this.loading = false; },
+      // Always show the confirmation screen — no enumeration leakage
+      error: () => { this.submitted = true; this.loading = false; }
+    });
+  }
+}

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -105,6 +105,11 @@
               <mat-error *ngIf="f['password'].hasError('pattern')">Must contain uppercase, lowercase and a number</mat-error>
             </mat-form-field>
 
+            <!-- Forgot password link — login mode only -->
+            <div class="forgot-link" *ngIf="!isRegister">
+              <a routerLink="/forgot-password">Forgot your password?</a>
+            </div>
+
             <!-- Register-only: Confirm Password -->
             <div class="extra-fields" [class.visible]="isRegister">
               <mat-form-field appearance="outline" class="full-width">

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -36,6 +36,11 @@
           <strong>{{ registeredEmail }}</strong>
         </p>
         <p class="inbox-hint">Click the link in the email to verify your account and get started. Check your spam folder if you don't see it.</p>
+        <button *ngIf="!resendSent" mat-stroked-button class="resend-btn" [disabled]="resendLoading" (click)="resendVerification(registeredEmail)">
+          <mat-spinner *ngIf="resendLoading" diameter="16"></mat-spinner>
+          <span *ngIf="!resendLoading">Resend verification email</span>
+        </button>
+        <p *ngIf="resendSent" class="resend-sent"><mat-icon>check_circle</mat-icon> Verification email resent!</p>
         <div class="toggle-link">
           <p>Already verified? <a tabindex="0" (click)="registrationComplete = false; isRegister = false" (keyup.enter)="registrationComplete = false; isRegister = false" (keydown.space)="registrationComplete = false; isRegister = false">Sign in</a></p>
         </div>
@@ -182,6 +187,11 @@
           <mat-icon>error</mat-icon>
           <span>{{ errorMessage }}</span>
         </div>
+        <p *ngIf="unverifiedLoginEmail" class="resend-hint">
+          Didn't get the email?
+          <a *ngIf="!resendSent" tabindex="0" [class.disabled]="resendLoading" (click)="!resendLoading && resendVerification(unverifiedLoginEmail)" (keyup.enter)="!resendLoading && resendVerification(unverifiedLoginEmail)">Resend verification email</a>
+          <span *ngIf="resendSent" class="resend-confirmed">Sent!</span>
+        </p>
 
         <!-- Submit Button -->
         <button

--- a/src/app/auth/login/login.component.scss
+++ b/src/app/auth/login/login.component.scss
@@ -430,6 +430,63 @@ mat-form-field {
   }
 }
 
+// ── Resend verification ───────────────────────────────────────────
+.resend-btn {
+  border-color: rgba(43, 184, 138, 0.35) !important;
+  color: #2BB88A !important;
+  border-radius: var(--radius-full) !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
+  height: 36px;
+  padding: 0 var(--spacing-lg) !important;
+
+  mat-spinner { display: inline-block; margin-right: var(--spacing-xs); }
+
+  :host-context([data-theme="light"]) & {
+    border-color: var(--color-accent-300) !important;
+  }
+}
+
+.resend-sent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #2BB88A;
+
+  mat-icon { font-size: 1rem; width: 1rem; height: 1rem; }
+}
+
+.resend-hint {
+  margin: calc(-1 * var(--spacing-sm)) 0 var(--spacing-md);
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.50);
+  text-align: center;
+
+  a {
+    color: #2BB88A;
+    font-weight: 600;
+    cursor: pointer;
+    margin-left: 4px;
+    &:hover { color: #1A8D6F; }
+    &.disabled { opacity: 0.5; cursor: default; }
+  }
+
+  .resend-confirmed {
+    color: #2BB88A;
+    font-weight: 600;
+    margin-left: 4px;
+  }
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-tertiary);
+  }
+}
+
+
 // ── Responsive ────────────────────────────────────────────────────
 // Tablet — register collapses to single column
 @media (max-width: 860px) {

--- a/src/app/auth/login/login.component.scss
+++ b/src/app/auth/login/login.component.scss
@@ -371,6 +371,26 @@ mat-form-field {
   }
 }
 
+// ── Forgot password link ──────────────────────────────────────────
+.forgot-link {
+  text-align: right;
+  margin-top: calc(-1 * var(--spacing-xs));
+  margin-bottom: var(--spacing-sm);
+
+  a {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.50);
+    text-decoration: none;
+    cursor: pointer;
+    transition: color var(--transition-fast);
+    &:hover { color: #2BB88A; }
+  }
+
+  :host-context([data-theme="light"]) & a {
+    color: var(--color-text-secondary);
+  }
+}
+
 // ── Check-inbox screen ────────────────────────────────────────────
 .inbox-check {
   display: flex;

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -49,6 +49,9 @@ export class LoginComponent implements OnInit {
   returnUrl = '/';
   registrationComplete = false;
   registeredEmail = '';
+  resendLoading = false;
+  resendSent = false;
+  unverifiedLoginEmail = '';
 
   // Consent step (register only)
   tcVersion = '1.0';
@@ -100,6 +103,8 @@ export class LoginComponent implements OnInit {
   toggleMode(): void {
     this.isRegister = !this.isRegister;
     this.errorMessage = '';
+    this.unverifiedLoginEmail = '';
+    this.resendSent = false;
     this.authForm.reset({ role: 'FREELANCER' });
     this.hidePassword = true;
     this.hideConfirmPassword = true;
@@ -191,10 +196,27 @@ export class LoginComponent implements OnInit {
         },
         error: (err) => {
           this.loading = false;
+          if (err.status === 403) {
+            this.unverifiedLoginEmail = this.authForm.value.email;
+          }
           this.errorMessage = err.error?.message || 'Login failed. Please check your credentials.';
         }
       });
     }
+  }
+
+  resendVerification(email: string): void {
+    this.resendLoading = true;
+    this.authService.resendVerification(email).subscribe({
+      next: () => {
+        this.resendLoading = false;
+        this.resendSent = true;
+      },
+      error: () => {
+        this.resendLoading = false;
+        this.snackBar.open('Could not resend. Please try again shortly.', 'Dismiss', { duration: 4000 });
+      }
+    });
   }
 
   private passwordMatchValidator(group: FormGroup): Record<string, boolean> | null {

--- a/src/app/auth/reset-password/reset-password.component.html
+++ b/src/app/auth/reset-password/reset-password.component.html
@@ -1,0 +1,109 @@
+<div class="rp-container">
+  <mat-card class="rp-card">
+
+    <mat-card-header>
+      <div class="brand-header">
+        <div class="brand-logo">
+          <svg viewBox="0 0 64 52" width="40" height="32" xmlns="http://www.w3.org/2000/svg">
+            <path d="M2 13 C14 13 20 29 32 29 C44 29 50 13 62 13" stroke="#2BB88A" stroke-width="7" fill="none" stroke-linecap="round"/>
+            <path d="M2 39 C14 39 20 23 32 23 C44 23 50 39 62 39" stroke="#2BB88A" stroke-width="7" fill="none" stroke-linecap="round" opacity="0.5"/>
+          </svg>
+          <span class="brand-wordmark"><strong>free</strong>work</span>
+        </div>
+        @if (success) {
+          <mat-card-title>Password updated</mat-card-title>
+          <mat-card-subtitle>Redirecting you to sign in…</mat-card-subtitle>
+        } @else if (invalidToken) {
+          <mat-card-title>Link expired</mat-card-title>
+          <mat-card-subtitle>This reset link is invalid or has expired</mat-card-subtitle>
+        } @else {
+          <mat-card-title>Choose a new password</mat-card-title>
+          <mat-card-subtitle>Must be at least 8 characters with uppercase, lowercase, digit and symbol</mat-card-subtitle>
+        }
+      </div>
+    </mat-card-header>
+
+    <mat-card-content>
+
+      @if (success) {
+        <div class="state-block">
+          <div class="state-icon success">
+            <mat-icon>check_circle</mat-icon>
+          </div>
+          <p>Your password has been reset. Redirecting you to sign in…</p>
+        </div>
+      } @else if (invalidToken) {
+        <div class="state-block">
+          <div class="state-icon error">
+            <mat-icon>link_off</mat-icon>
+          </div>
+          <p>This link has expired or is invalid. Reset links are valid for 1 hour and can only be used once.</p>
+          <a mat-stroked-button routerLink="/forgot-password" class="request-new-btn">Request a new link</a>
+        </div>
+      } @else {
+        @if (errorMessage) {
+          <div class="error-message">
+            <mat-icon>error</mat-icon>
+            <span>{{ errorMessage }}</span>
+          </div>
+        }
+
+        <form [formGroup]="form" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>New password</mat-label>
+            <input
+              matInput
+              [type]="hidePassword ? 'password' : 'text'"
+              formControlName="newPassword"
+              placeholder="Create a strong password"
+              autocomplete="new-password">
+            <mat-icon matPrefix>lock</mat-icon>
+            <button mat-icon-button matSuffix type="button" (click)="hidePassword = !hidePassword">
+              <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
+            @if (form.get('newPassword')?.hasError('required') && form.get('newPassword')?.touched) {
+              <mat-error>Password is required</mat-error>
+            } @else if (form.get('newPassword')?.hasError('minlength') && form.get('newPassword')?.touched) {
+              <mat-error>At least 8 characters required</mat-error>
+            } @else if (form.get('newPassword')?.hasError('pattern') && form.get('newPassword')?.touched) {
+              <mat-error>Must contain uppercase, lowercase, digit and special character</mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Confirm new password</mat-label>
+            <input
+              matInput
+              [type]="hideConfirm ? 'password' : 'text'"
+              formControlName="confirmPassword"
+              placeholder="Re-enter your password"
+              autocomplete="new-password">
+            <mat-icon matPrefix>lock</mat-icon>
+            <button mat-icon-button matSuffix type="button" (click)="hideConfirm = !hideConfirm">
+              <mat-icon>{{ hideConfirm ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
+            @if (form.get('confirmPassword')?.hasError('required') && form.get('confirmPassword')?.touched) {
+              <mat-error>Please confirm your password</mat-error>
+            } @else if (form.get('confirmPassword')?.hasError('mismatch') && form.get('confirmPassword')?.touched) {
+              <mat-error>Passwords do not match</mat-error>
+            }
+          </mat-form-field>
+
+          <button mat-raised-button color="primary" type="submit" class="full-width submit-btn" [disabled]="loading">
+            @if (loading) {
+              <mat-spinner diameter="20"></mat-spinner>
+              Updating…
+            } @else {
+              Set new password
+            }
+          </button>
+        </form>
+      }
+
+      <div class="back-link">
+        <a routerLink="/login">← Back to sign in</a>
+      </div>
+    </mat-card-content>
+
+  </mat-card>
+</div>

--- a/src/app/auth/reset-password/reset-password.component.scss
+++ b/src/app/auth/reset-password/reset-password.component.scss
@@ -1,0 +1,254 @@
+:host {
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.rp-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100%;
+  padding: var(--spacing-xl);
+  background: url('/assets/Login_page_dark_new.png') center center / cover no-repeat fixed;
+
+  :host-context([data-theme="light"]) & {
+    background: url('/assets/Login_page_light_new.png') center center / cover no-repeat fixed;
+  }
+}
+
+.rp-card {
+  width: 420px;
+  max-width: calc(100vw - 2 * var(--spacing-xl));
+  box-sizing: border-box;
+  background: rgba(13, 31, 26, 0.55) !important;
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border-radius: var(--radius-xl) !important;
+  border: 1px solid rgba(43, 184, 138, 0.20) !important;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(43, 184, 138, 0.08) !important;
+
+  :host-context([data-theme="light"]) & {
+    background: rgba(255, 255, 255, 0.65) !important;
+    border: 1px solid rgba(43, 184, 138, 0.20) !important;
+    box-shadow: 0 8px 40px rgba(26, 141, 111, 0.12), 0 0 0 1px rgba(43, 184, 138, 0.10) !important;
+  }
+
+  .mdc-card, .mat-mdc-card-content {
+    border-radius: var(--radius-xl) !important;
+    background: transparent !important;
+  }
+}
+
+mat-card-header {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-2xl) var(--spacing-2xl) var(--spacing-xl);
+  text-align: center;
+}
+
+.brand-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+  width: 100%;
+}
+
+.brand-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: var(--spacing-xs);
+}
+
+.brand-wordmark {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 1.375rem;
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  color: rgba(255, 255, 255, 0.55);
+
+  strong {
+    font-weight: 700;
+    color: #ffffff;
+  }
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-secondary);
+    strong { color: var(--color-text-primary); }
+  }
+}
+
+mat-card-title {
+  font-family: 'Bricolage Grotesque', sans-serif !important;
+  font-size: 1.625rem !important;
+  font-weight: 700 !important;
+  margin-bottom: var(--spacing-xs) !important;
+  color: #ffffff !important;
+  letter-spacing: -0.025em !important;
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-primary) !important;
+  }
+}
+
+mat-card-subtitle {
+  font-size: 14px !important;
+  color: rgba(255, 255, 255, 0.65) !important;
+  font-weight: 400 !important;
+  line-height: 1.5 !important;
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-secondary) !important;
+  }
+}
+
+mat-card-content,
+::ng-deep .mat-mdc-card-content {
+  padding: 0 var(--spacing-2xl) var(--spacing-xl) !important;
+}
+
+.full-width { width: 100%; }
+
+mat-form-field {
+  width: 100%;
+  margin-bottom: var(--spacing-xs);
+}
+
+.submit-btn {
+  width: 100%;
+  height: 44px;
+  font-size: 15px;
+  font-weight: 600;
+  margin-top: var(--spacing-xs);
+  background-color: var(--color-accent-600) !important;
+  color: white !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: none !important;
+  transition: all var(--transition-fast) !important;
+
+  &:hover:not([disabled]) {
+    background-color: var(--color-accent-700) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(26, 141, 111, 0.35) !important;
+  }
+
+  mat-spinner { display: inline-block; margin-right: var(--spacing-sm); }
+}
+
+.state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--spacing-xl) 0 var(--spacing-md);
+  gap: var(--spacing-md);
+}
+
+.state-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 2rem;
+    width: 2rem;
+    height: 2rem;
+  }
+
+  &.success {
+    background: rgba(43, 184, 138, 0.12);
+    border: 1px solid rgba(43, 184, 138, 0.25);
+    mat-icon { color: #2BB88A; }
+  }
+
+  &.error {
+    background: var(--color-error-50);
+    border: 1px solid rgba(248, 113, 113, 0.30);
+    mat-icon { color: var(--color-error-500); }
+  }
+}
+
+.state-block p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.6;
+  max-width: 320px;
+
+  :host-context([data-theme="light"]) & {
+    color: var(--color-text-secondary);
+  }
+}
+
+.request-new-btn {
+  border-color: rgba(43, 184, 138, 0.35) !important;
+  color: #2BB88A !important;
+  border-radius: var(--radius-full) !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
+  margin-top: var(--spacing-sm);
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  background-color: var(--color-error-50);
+  color: var(--color-error-500);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(248, 113, 113, 0.30);
+  margin-bottom: var(--spacing-lg);
+  font-size: 14px;
+  line-height: 1.5;
+
+  mat-icon {
+    flex-shrink: 0;
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+.back-link {
+  text-align: center;
+  padding-top: var(--spacing-lg);
+
+  a {
+    color: #2BB88A;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: color var(--transition-fast);
+    &:hover { color: #1A8D6F; }
+  }
+}
+
+@media (max-width: 600px) {
+  .rp-container {
+    align-items: flex-start;
+    padding: var(--spacing-md);
+  }
+
+  .rp-card {
+    width: 100%;
+    max-width: calc(100vw - 2 * var(--spacing-md));
+  }
+
+  mat-card-header {
+    padding: var(--spacing-xl) var(--spacing-md) var(--spacing-md) !important;
+  }
+
+  mat-card-title { font-size: 1.375rem !important; }
+
+  mat-card-content,
+  ::ng-deep .mat-mdc-card-content {
+    padding: 0 var(--spacing-md) var(--spacing-md) !important;
+  }
+}

--- a/src/app/auth/reset-password/reset-password.component.ts
+++ b/src/app/auth/reset-password/reset-password.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnInit } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { Router, RouterLink, ActivatedRoute } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { AuthService } from '../auth.service';
+
+function confirmPasswordValidator(control: AbstractControl): ValidationErrors | null {
+  const parent = control.parent;
+  if (!parent) return null;
+  return parent.get('newPassword')?.value === control.value ? null : { mismatch: true };
+}
+
+@Component({
+  selector: 'app-reset-password',
+  imports: [
+    ReactiveFormsModule,
+    RouterLink,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './reset-password.component.html',
+  styleUrl: './reset-password.component.scss'
+})
+export class ResetPasswordComponent implements OnInit {
+  form: FormGroup;
+  token = '';
+  loading = false;
+  success = false;
+  invalidToken = false;
+  errorMessage = '';
+  hidePassword = true;
+  hideConfirm = true;
+
+  private readonly PASSWORD_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&_#\-]).+$/;
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private authService: AuthService
+  ) {
+    this.form = this.fb.group({
+      newPassword: ['', [Validators.required, Validators.minLength(8), Validators.pattern(this.PASSWORD_PATTERN)]],
+      confirmPassword: ['', [Validators.required, confirmPasswordValidator]]
+    });
+
+    this.form.get('newPassword')?.valueChanges.subscribe(() => {
+      this.form.get('confirmPassword')?.updateValueAndValidity();
+    });
+  }
+
+  ngOnInit(): void {
+    this.token = this.route.snapshot.queryParamMap.get('token') ?? '';
+    if (!this.token) this.invalidToken = true;
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.loading || !this.token) return;
+    this.loading = true;
+    this.errorMessage = '';
+
+    this.authService.resetPassword(this.token, this.form.value.newPassword as string).subscribe({
+      next: () => {
+        this.success = true;
+        this.loading = false;
+        setTimeout(() => this.router.navigate(['/login']), 3000);
+      },
+      error: (err: { error?: { message?: string } }) => {
+        this.loading = false;
+        const msg = (err?.error?.message ?? '').toLowerCase();
+        if (msg.includes('invalid') || msg.includes('expired')) {
+          this.invalidToken = true;
+        } else {
+          this.errorMessage = 'Something went wrong. Please try again or request a new reset link.';
+        }
+      }
+    });
+  }
+}

--- a/src/app/auth/reset-password/reset-password.component.ts
+++ b/src/app/auth/reset-password/reset-password.component.ts
@@ -40,7 +40,7 @@ export class ResetPasswordComponent implements OnInit {
   hidePassword = true;
   hideConfirm = true;
 
-  private readonly PASSWORD_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&_#\-]).+$/;
+  private readonly PASSWORD_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&_#-]).+$/;
 
   constructor(
     private fb: FormBuilder,

--- a/src/app/auth/token.interceptor.spec.ts
+++ b/src/app/auth/token.interceptor.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient, withInterceptors, HttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { AuthService } from './auth.service';
+import { tokenInterceptor } from './token.interceptor';
+import { AuthResponse } from './models';
+
+describe('tokenInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let authService: jasmine.SpyObj<AuthService>;
+
+  const mockRefreshResponse: AuthResponse = {
+    accessToken: 'new-access-token',
+    refreshToken: 'new-refresh-token',
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    user: { id: '1', email: 'test@example.com', firstName: 'T', lastName: 'U', role: 'FREELANCER', createdAt: '' }
+  };
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj('AuthService', ['getAccessToken', 'refreshToken', 'logout']);
+    authService.getAccessToken.and.returnValue(null);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authService },
+        provideHttpClient(withInterceptors([tokenInterceptor])),
+        provideHttpClientTesting()
+      ]
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('does not add Authorization header when no token', () => {
+    authService.getAccessToken.and.returnValue(null);
+    http.get('/api/jobs').subscribe();
+
+    const req = httpMock.expectOne('/api/jobs');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
+  });
+
+  it('adds Bearer Authorization header when token exists', () => {
+    authService.getAccessToken.and.returnValue('my-access-token');
+    http.get('/api/jobs').subscribe();
+
+    const req = httpMock.expectOne('/api/jobs');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer my-access-token');
+    req.flush({});
+  });
+
+  it('skips Authorization header for /auth/login', () => {
+    authService.getAccessToken.and.returnValue('my-access-token');
+    http.post('/auth/login', {}).subscribe();
+
+    const req = httpMock.expectOne('/auth/login');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
+  });
+
+  it('skips Authorization header for /auth/register', () => {
+    authService.getAccessToken.and.returnValue('my-access-token');
+    http.post('/auth/register', {}).subscribe();
+
+    const req = httpMock.expectOne('/auth/register');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
+  });
+
+  it('always sets Content-Type and Accept headers', () => {
+    authService.getAccessToken.and.returnValue(null);
+    http.get('/api/jobs').subscribe();
+
+    const req = httpMock.expectOne('/api/jobs');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    req.flush({});
+  });
+
+  it('attempts token refresh on 401 and retries the request', () => {
+    authService.getAccessToken.and.returnValue('expired-token');
+    authService.refreshToken.and.returnValue(of(mockRefreshResponse));
+
+    let result: unknown;
+    http.get('/api/jobs').subscribe(r => { result = r; });
+
+    const firstReq = httpMock.expectOne('/api/jobs');
+    firstReq.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    const retryReq = httpMock.expectOne('/api/jobs');
+    retryReq.flush([{ id: '1' }]);
+
+    expect(authService.refreshToken).toHaveBeenCalled();
+    expect(result).toEqual([{ id: '1' }]);
+  });
+
+  it('logs out when token refresh fails on 401', () => {
+    authService.getAccessToken.and.returnValue('expired-token');
+    authService.refreshToken.and.returnValue(throwError(() => new Error('Refresh failed')));
+    authService.logout.and.stub();
+
+    let errored = false;
+    http.get('/api/jobs').subscribe({ error: () => { errored = true; } });
+
+    const req = httpMock.expectOne('/api/jobs');
+    req.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authService.logout).toHaveBeenCalled();
+    expect(errored).toBeTrue();
+  });
+});

--- a/src/app/jobs/job-detail/job-detail.component.ts
+++ b/src/app/jobs/job-detail/job-detail.component.ts
@@ -13,6 +13,7 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { JobService } from '../job.service';
 import { AuthService } from '../../auth/auth.service';
+import { MessagingService } from '../../messaging/messaging.service';
 import { Job, JOB_CATEGORIES } from '../models';
 import { RatingSummaryComponent } from '../../reviews/rating-summary/rating-summary.component';
 import { ReviewListComponent } from '../../reviews/review-list/review-list.component';
@@ -50,6 +51,7 @@ export class JobDetailComponent implements OnInit {
     private router: Router,
     private jobService: JobService,
     private authService: AuthService,
+    private messagingService: MessagingService,
     private snackBar: MatSnackBar,
     private dialog: MatDialog
   ) {}
@@ -163,8 +165,12 @@ export class JobDetailComponent implements OnInit {
   }
 
   contactCustomer(): void {
-    // TODO: Implement messaging functionality
-    this.showSuccess('Messaging feature coming soon!');
+    if (!this.job?.customerId) return;
+    this.messagingService.getOrCreateConversation(this.job.customerId, this.job.id)
+      .subscribe({
+        next: (conversation) => this.router.navigate(['/messages', conversation.id]),
+        error: () => this.showError('Failed to start conversation')
+      });
   }
 
   goBack(): void {

--- a/src/app/legal/legal-content.ts
+++ b/src/app/legal/legal-content.ts
@@ -138,15 +138,15 @@ export const LEGAL_CONTENT: {
           heading: '9. Your Rights Under POPIA',
           content: `<p>As a data subject under POPIA, you have the following rights:</p>
 <ul>
-  <li><strong>Right to access:</strong> Request a copy of the personal information we hold about you</li>
+  <li><strong>Right to access:</strong> Request a copy of the personal information we hold about you — or download it yourself instantly from <strong>Settings &rarr; Download My Data</strong></li>
   <li><strong>Right to correction:</strong> Request correction of inaccurate or incomplete personal information</li>
-  <li><strong>Right to deletion:</strong> Request deletion of your personal information (subject to legal retention requirements)</li>
+  <li><strong>Right to deletion:</strong> Request deletion of your personal information (subject to legal retention requirements). When you delete your account we anonymise your personal data rather than permanently erasing records we must keep for legal or financial compliance</li>
   <li><strong>Right to object:</strong> Object to the processing of your personal information for direct marketing</li>
-  <li><strong>Right to data portability:</strong> Request your data in a structured, machine-readable format</li>
+  <li><strong>Right to data portability:</strong> Obtain your data in a structured, machine-readable format — available immediately as a JSON export from <strong>Settings &rarr; Download My Data</strong></li>
   <li><strong>Right to withdraw consent:</strong> Withdraw consent at any time where processing is based on consent</li>
   <li><strong>Right to lodge a complaint:</strong> Lodge a complaint with the Information Regulator of South Africa</li>
 </ul>
-<p>To exercise any of these rights, submit a request at <strong>/legal/popia-request</strong> or email us at <a href="mailto:privacy@freework.co.za">privacy@freework.co.za</a>.</p>`,
+<p>You can access and export your own data immediately from <strong>Settings &rarr; Download My Data</strong>. To exercise any other right, submit a request at <strong>/legal/popia-request</strong> or email us at <a href="mailto:privacy@freework.co.za">privacy@freework.co.za</a>. We respond to formal requests within 30 days as required by POPIA; an access or portability request you have lodged is automatically marked complete once you download your data export.</p>`,
           callout: 'Information Regulator of South Africa: Email: inforeg@justice.gov.za | Phone: 010 023 5207 | Website: www.justice.gov.za/inforeg/',
           calloutType: 'info'
         },

--- a/src/app/legal/legal.service.ts
+++ b/src/app/legal/legal.service.ts
@@ -98,4 +98,12 @@ export class LegalService {
       body: { confirmation }
     });
   }
+
+  /**
+   * POPIA right of access / data portability — downloads all personal data the backend
+   * holds about the current user as a JSON blob.
+   */
+  exportMyData(): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/api/account/export`, { responseType: 'blob' });
+  }
 }

--- a/src/app/messaging/websocket.service.ts
+++ b/src/app/messaging/websocket.service.ts
@@ -11,37 +11,31 @@ export class WebSocketService {
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
   private reconnectInterval = 3000;
+  private authFailed = false;
 
-  // Subjects for different message types
   private messageSubject = new Subject<Message>();
   private typingSubject = new Subject<TypingIndicator>();
   private notificationSubject = new Subject<MessageNotification>();
   private connectionSubject = new BehaviorSubject<boolean>(false);
 
-  // Public observables
   public message$ = this.messageSubject.asObservable();
   public typing$ = this.typingSubject.asObservable();
   public notification$ = this.notificationSubject.asObservable();
   public connected$ = this.connectionSubject.asObservable();
 
-  /**
-   * Connect to WebSocket server
-   */
   connect(token: string): void {
     if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-      console.log('WebSocket already connected');
       return;
     }
 
-    const wsUrl = `${WS_BASE_URL}/ws?token=${token}`;
+    this.authFailed = false;
 
     try {
-      this.socket = new WebSocket(wsUrl);
+      this.socket = new WebSocket(`${WS_BASE_URL}/ws`);
 
       this.socket.onopen = () => {
-        console.log('WebSocket connected');
-        this.connectionSubject.next(true);
         this.reconnectAttempts = 0;
+        this.socket!.send(JSON.stringify({ type: 'AUTH', token }));
       };
 
       this.socket.onmessage = (event) => {
@@ -54,9 +48,10 @@ export class WebSocketService {
       };
 
       this.socket.onclose = () => {
-        console.log('WebSocket disconnected');
         this.connectionSubject.next(false);
-        this.attemptReconnect(token);
+        if (!this.authFailed) {
+          this.attemptReconnect(token);
+        }
       };
     } catch (error) {
       console.error('Failed to create WebSocket connection:', error);
@@ -64,9 +59,6 @@ export class WebSocketService {
     }
   }
 
-  /**
-   * Disconnect from WebSocket server
-   */
   disconnect(): void {
     if (this.socket) {
       this.socket.close();
@@ -75,9 +67,6 @@ export class WebSocketService {
     }
   }
 
-  /**
-   * Send a message through WebSocket
-   */
   send(message: Record<string, unknown>): void {
     if (this.socket && this.socket.readyState === WebSocket.OPEN) {
       this.socket.send(JSON.stringify(message));
@@ -86,35 +75,31 @@ export class WebSocketService {
     }
   }
 
-  /**
-   * Send typing indicator
-   */
   sendTypingIndicator(conversationId: string, isTyping: boolean): void {
-    this.send({
-      type: 'TYPING',
-      conversationId,
-      isTyping
-    });
+    this.send({ type: 'TYPING', conversationId, isTyping });
   }
 
-  /**
-   * Mark messages as read
-   */
   markAsRead(conversationId: string): void {
-    this.send({
-      type: 'MARK_READ',
-      conversationId
-    });
+    this.send({ type: 'MARK_READ', conversationId });
   }
 
-  /**
-   * Handle incoming WebSocket messages
-   */
+  isConnected(): boolean {
+    return this.socket !== null && this.socket.readyState === WebSocket.OPEN;
+  }
+
   private handleMessage(data: string): void {
     try {
       const payload = JSON.parse(data);
 
       switch (payload.type) {
+        case 'AUTH_OK':
+          this.connectionSubject.next(true);
+          break;
+        case 'AUTH_ERROR':
+          console.error('WebSocket auth failed:', payload.message);
+          this.authFailed = true;
+          this.socket?.close();
+          break;
         case 'MESSAGE':
           this.messageSubject.next(payload.message);
           break;
@@ -125,7 +110,6 @@ export class WebSocketService {
           this.notificationSubject.next(payload.notification);
           break;
         case 'READ_RECEIPT':
-          // Handle read receipts
           break;
         default:
           console.log('Unknown message type:', payload.type);
@@ -135,26 +119,13 @@ export class WebSocketService {
     }
   }
 
-  /**
-   * Attempt to reconnect to WebSocket
-   */
   private attemptReconnect(token: string): void {
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.reconnectAttempts++;
       console.log(`Attempting to reconnect... (${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
-
-      setTimeout(() => {
-        this.connect(token);
-      }, this.reconnectInterval);
+      setTimeout(() => this.connect(token), this.reconnectInterval);
     } else {
       console.error('Max reconnection attempts reached');
     }
-  }
-
-  /**
-   * Check if WebSocket is connected
-   */
-  isConnected(): boolean {
-    return this.socket !== null && this.socket.readyState === WebSocket.OPEN;
   }
 }

--- a/src/app/payments/payment.service.spec.ts
+++ b/src/app/payments/payment.service.spec.ts
@@ -1,0 +1,132 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { PaymentService } from './payment.service';
+import { buildApiEndpointUrl } from '../api.config';
+import { PaymentMethod, PaymentType, PaymentStatus } from './models/payment.models';
+
+describe('PaymentService', () => {
+  let service: PaymentService;
+  let httpMock: HttpTestingController;
+
+  const API_URL = buildApiEndpointUrl('/payments');
+
+  const mockPayment = {
+    id: 'pay-1',
+    jobId: 'job-1',
+    amount: 5000,
+    currency: 'ZAR',
+    status: PaymentStatus.PENDING,
+    createdAt: '2024-01-01T00:00:00Z'
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PaymentService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(PaymentService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getPayments()', () => {
+    it('GETs /payments and returns list', () => {
+      let result: unknown[] = [];
+      service.getPayments().subscribe(r => { result = r; });
+
+      const req = httpMock.expectOne(API_URL);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockPayment]);
+
+      expect(result.length).toBe(1);
+    });
+  });
+
+  describe('getPayment()', () => {
+    it('GETs /payments/:id', () => {
+      let result: unknown;
+      service.getPayment('pay-1').subscribe(r => { result = r; });
+
+      const req = httpMock.expectOne(`${API_URL}/pay-1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockPayment);
+
+      expect(result).toEqual(mockPayment);
+    });
+  });
+
+  describe('getJobPayments()', () => {
+    it('GETs /payments/job/:jobId', () => {
+      service.getJobPayments('job-1').subscribe();
+
+      const req = httpMock.expectOne(`${API_URL}/job/job-1`);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockPayment]);
+    });
+  });
+
+  describe('createCheckout()', () => {
+    it('POSTs to /payments/checkout and returns checkoutUrl', () => {
+      const checkoutResponse = { checkoutUrl: 'https://www.payfast.co.za/eng/process?...' };
+      let result: unknown;
+      service.createCheckout({
+        jobId: 'job-1',
+        amount: 5000,
+        currency: 'ZAR',
+        paymentMethod: PaymentMethod.CARD,
+        paymentType: PaymentType.JOB_ESCROW,
+        description: 'Escrow for job'
+      }).subscribe(r => { result = r; });
+
+      const req = httpMock.expectOne(`${API_URL}/checkout`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body.jobId).toBe('job-1');
+      req.flush(checkoutResponse);
+
+      expect(result).toEqual(checkoutResponse);
+    });
+  });
+
+  describe('releasePayment()', () => {
+    it('POSTs to /payments/release', () => {
+      service.releasePayment({ paymentId: 'pay-1', amount: 1000 }).subscribe();
+
+      const req = httpMock.expectOne(`${API_URL}/release`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ paymentId: 'pay-1', amount: 1000 });
+      req.flush(mockPayment);
+    });
+  });
+
+  describe('refundPayment()', () => {
+    it('POSTs to /payments/refund', () => {
+      service.refundPayment({ paymentId: 'pay-1', amount: 1000, reason: 'Customer request' }).subscribe();
+
+      const req = httpMock.expectOne(`${API_URL}/refund`);
+      expect(req.request.method).toBe('POST');
+      req.flush(mockPayment);
+    });
+  });
+
+  describe('updatePaymentStatus()', () => {
+    it('emits updated status via paymentStatus$', () => {
+      const update = { paymentId: 'pay-1', status: PaymentStatus.RELEASED, updatedAt: new Date() };
+      let emitted: unknown;
+      service.paymentStatus$.subscribe(s => { emitted = s; });
+
+      service.updatePaymentStatus(update);
+
+      expect(emitted).toEqual(update);
+    });
+  });
+});

--- a/src/app/payments/stripe-payment/stripe-payment.component.ts
+++ b/src/app/payments/stripe-payment/stripe-payment.component.ts
@@ -13,7 +13,7 @@ import { PaymentMethod, PaymentType } from '../models/payment.models';
 import { Job } from '../../jobs/models';
 
 @Component({
-    selector: 'app-stripe-payment',
+    selector: 'app-checkout-payment',
     imports: [
         CommonModule,
         RouterLink,
@@ -27,7 +27,7 @@ import { Job } from '../../jobs/models';
     templateUrl: './stripe-payment.component.html',
     styleUrls: ['./stripe-payment.component.scss']
 })
-export class StripePaymentComponent implements OnInit {
+export class CheckoutPaymentComponent implements OnInit {
   job: Job | null = null;
   loading = true;
   redirecting = false;

--- a/src/app/profile/profile.service.ts
+++ b/src/app/profile/profile.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, BehaviorSubject, of, throwError } from 'rxjs';
-import { tap, catchError, delay } from 'rxjs/operators';
+import { Observable, BehaviorSubject, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
 import { Profile, UpdateProfileRequest, FreelancerProfile, CustomerProfile } from './models/profile.models';
 import { AuthService } from '../auth/auth.service';
 import { buildApiEndpointUrl } from '../api.config';
@@ -11,22 +11,14 @@ import { buildApiEndpointUrl } from '../api.config';
 })
 export class ProfileService {
   private readonly API_URL = buildApiEndpointUrl('/profile');
-  private useMockData = false; // Toggle for testing
 
   private currentProfileSubject = new BehaviorSubject<Profile | null>(null);
   public currentProfile$ = this.currentProfileSubject.asObservable();
-
-  // Mock data for testing
-  private mockProfiles = new Map<string, Profile>();
 
   constructor(
     private http: HttpClient,
     private authService: AuthService
   ) {
-    // Initialize mock data
-    this.initializeMockData();
-
-    // Load profile when user logs in
     this.authService.currentUser$.subscribe(user => {
       if (user) {
         this.getMyProfile().subscribe();
@@ -36,278 +28,57 @@ export class ProfileService {
     });
   }
 
-  private initializeMockData() {
-    const freelancerProfile: FreelancerProfile = {
-      id: 'profile-1',
-      userId: 'freelancer1',
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'john@example.com',
-      phone: '+1 (555) 123-4567',
-      profilePicture: 'https://i.pravatar.cc/150?img=12',
-      bio: 'Full-stack developer with 5+ years of experience in building scalable web applications. Specialized in Angular, React, Node.js, and cloud technologies.',
-      location: 'San Francisco, CA',
-      role: 'FREELANCER',
-      title: 'Full Stack Developer',
-      hourlyRate: 75,
-      skills: ['Angular', 'TypeScript', 'Node.js', 'Python', 'AWS', 'MongoDB', 'PostgreSQL', 'Docker'],
-      experience: '5+ years',
-      education: 'BS in Computer Science, Stanford University',
-      availability: 'FULL_TIME',
-      rating: 4.8,
-      totalReviews: 24,
-      completedJobs: 47,
-      languages: [
-        { name: 'English', proficiency: 'NATIVE' },
-        { name: 'Spanish', proficiency: 'CONVERSATIONAL' }
-      ],
-      portfolio: [
-        {
-          id: 'port-1',
-          title: 'E-commerce Platform',
-          description: 'Built a full-featured e-commerce platform with real-time inventory management',
-          imageUrl: 'https://via.placeholder.com/400x300',
-          technologies: ['Angular', 'Node.js', 'MongoDB'],
-          completedAt: '2024-06-15'
-        },
-        {
-          id: 'port-2',
-          title: 'Task Management App',
-          description: 'Developed a collaborative task management application',
-          imageUrl: 'https://via.placeholder.com/400x300',
-          technologies: ['React', 'Firebase', 'Material-UI'],
-          completedAt: '2024-03-20'
-        }
-      ],
-      certifications: [
-        {
-          id: 'cert-1',
-          name: 'AWS Certified Solutions Architect',
-          issuer: 'Amazon Web Services',
-          issueDate: '2023-05-15',
-          expiryDate: '2026-05-15',
-          credentialUrl: 'https://aws.amazon.com/verification'
-        }
-      ],
-      socialLinks: {
-        linkedin: 'https://linkedin.com/in/johndoe',
-        github: 'https://github.com/johndoe',
-        website: 'https://johndoe.dev'
-      },
-      createdAt: '2024-01-15T10:00:00Z',
-      updatedAt: '2024-09-20T15:30:00Z'
-    };
-
-    const customerProfile: CustomerProfile = {
-      id: 'profile-2',
-      userId: 'emily-chen',
-      firstName: 'Emily',
-      lastName: 'Chen',
-      email: 'emily@example.com',
-      phone: '+1 (555) 987-6543',
-      profilePicture: 'https://i.pravatar.cc/150?img=20',
-      bio: 'Product manager and entrepreneur looking for talented freelancers to build innovative products.',
-      location: 'New York, NY',
-      role: 'CUSTOMER',
-      company: 'TechVentures Inc.',
-      companySize: '11-50 employees',
-      industry: 'Technology',
-      website: 'https://techventures.example.com',
-      rating: 4.9,
-      totalReviews: 15,
-      totalJobsPosted: 28,
-      verifiedPayment: true,
-      socialLinks: {
-        linkedin: 'https://linkedin.com/in/emilychen',
-        twitter: 'https://twitter.com/emilychen',
-        website: 'https://techventures.example.com'
-      },
-      createdAt: '2024-03-20T14:30:00Z',
-      updatedAt: '2024-09-18T10:15:00Z'
-    };
-
-    this.mockProfiles.set('freelancer1', freelancerProfile);
-    this.mockProfiles.set('emily-chen', customerProfile);
-  }
-
-  /**
-   * Get current user's profile
-   */
   getMyProfile(): Observable<Profile> {
     const user = this.authService.currentUserValue;
     if (!user) {
-      console.error('❌ Cannot get profile: No user logged in');
       return throwError(() => new Error('User not authenticated'));
     }
 
-    console.log('🔧 Getting profile for user:', user.id, '- Mock mode:', this.useMockData);
-
-    if (this.useMockData) {
-      console.log('✅ Using mock profile data');
-      return this.getMockProfile(user.id);
-    }
-
-    console.log('⚠️ Calling real API:', `${this.API_URL}`);
     return this.http.get<Profile>(`${this.API_URL}`)
       .pipe(
-        tap(profile => {
-          console.log('✅ Profile loaded from API:', profile);
-          this.currentProfileSubject.next(profile);
-        }),
-        catchError(error => {
-          console.error('❌ Error loading profile from API:', error);
-          console.log('🔄 Falling back to mock data...');
-
-          // Fallback to mock data
-          return this.getMockProfile(user.id).pipe(
-            tap(() => console.log('✅ Using mock profile as fallback'))
-          );
-        })
+        tap(profile => this.currentProfileSubject.next(profile)),
+        catchError(error => throwError(() => error))
       );
   }
 
-  /**
-   * Get profile by user ID
-   */
   getProfileByUserId(userId: string): Observable<Profile> {
-    console.log('🔧 Getting profile by userId:', userId, '- Mock mode:', this.useMockData);
-
-    if (this.useMockData) {
-      console.log('✅ Using mock profile data');
-      return this.getMockProfile(userId);
-    }
-
-    console.log('⚠️ Calling real API:', `${this.API_URL}/user/${userId}`);
     return this.http.get<Profile>(`${this.API_URL}/user/${userId}`)
       .pipe(
-        tap(profile => console.log('✅ Profile loaded from API:', profile)),
-        catchError(error => {
-          console.error('❌ Error loading profile from API:', error);
-          console.log('🔄 Falling back to mock data...');
-
-          // Fallback to mock data
-          return this.getMockProfile(userId).pipe(
-            tap(() => console.log('✅ Using mock profile as fallback'))
-          );
-        })
+        catchError(error => throwError(() => error))
       );
   }
 
-  /**
-   * Update current user's profile
-   */
   updateProfile(updates: UpdateProfileRequest): Observable<Profile> {
-    if (this.useMockData) {
-      return this.updateMockProfile(updates);
-    }
-
     return this.http.put<Profile>(`${this.API_URL}`, updates)
       .pipe(
         tap(profile => {
           this.currentProfileSubject.next(profile);
-          // Update user in auth service if profile is now complete
           this.updateAuthUserProfile(profile);
         }),
-        catchError(error => {
-          console.error('Error updating profile:', error);
-          return throwError(() => error);
-        })
+        catchError(error => throwError(() => error))
       );
   }
 
-  /**
-   * Mark profile as completed
-   */
   markProfileAsCompleted(): Observable<unknown> {
-    if (this.useMockData) {
-      return of({ success: true }).pipe(
-        tap(() => {
-          const user = this.authService.currentUserValue;
-          if (user) {
-            // Update user in auth service
-            const updatedUser = { ...user, profileCompleted: true };
-            this.authService.updateCurrentUser(updatedUser);
-          }
-        })
-      );
-    }
-
     return this.http.post(`${this.API_URL}/mark-completed`, {})
       .pipe(
         tap(() => {
           const user = this.authService.currentUserValue;
           if (user) {
-            const updatedUser = { ...user, profileCompleted: true };
-            this.authService.updateCurrentUser(updatedUser);
+            this.authService.updateCurrentUser({ ...user, profileCompleted: true });
           }
         }),
-        catchError(error => {
-          console.error('Error marking profile as completed:', error);
-          return throwError(() => error);
-        })
+        catchError(error => throwError(() => error))
       );
   }
 
-  /**
-   * Update auth service user with profile completion status
-   */
-  private updateAuthUserProfile(profile: Profile): void {
-    const user = this.authService.currentUserValue;
-    if (user) {
-      const updatedUser = {
-        ...user,
-        profileCompleted: this.isProfileComplete(profile)
-      };
-      this.authService.updateCurrentUser(updatedUser);
-    }
-  }
-
-  /**
-   * Check if profile has required fields completed
-   */
-  isProfileComplete(profile: Profile): boolean {
-    // Basic required fields
-    const hasBasicInfo = !!(
-      profile.firstName &&
-      profile.lastName &&
-      profile.email
-    );
-
-    if (profile.role === 'CUSTOMER') {
-      const customerProfile = profile as CustomerProfile;
-      // Customers need at least company or industry info
-      return hasBasicInfo && !!(customerProfile.company || customerProfile.industry);
-    } else {
-      const freelancerProfile = profile as FreelancerProfile;
-      // Freelancers need skills and at least a title or hourly rate
-      return hasBasicInfo &&
-             !!(freelancerProfile.skills && freelancerProfile.skills.length > 0) &&
-             !!(freelancerProfile.title || freelancerProfile.hourlyRate);
-    }
-  }
-
-  /**
-   * Upload profile picture
-   */
   uploadProfilePicture(file: File): Observable<{ url: string }> {
-    if (this.useMockData) {
-      // Simulate upload
-      return of({ url: 'https://i.pravatar.cc/150?img=' + Math.floor(Math.random() * 70) })
-        .pipe(delay(1000));
-    }
-
-    // Convert the File to a data URL, then send the URL to the backend
     return new Observable<{ url: string }>(observer => {
       const reader = new FileReader();
       reader.onload = () => {
         const dataUrl = reader.result as string;
         this.http.post<{ url: string }>(`${this.API_URL}/upload-picture`, { url: dataUrl })
-          .pipe(
-            catchError(error => {
-              console.error('Error uploading picture:', error);
-              return throwError(() => error);
-            })
-          )
+          .pipe(catchError(error => throwError(() => error)))
           .subscribe(observer);
       };
       reader.onerror = () => observer.error(new Error('Failed to read file'));
@@ -315,54 +86,27 @@ export class ProfileService {
     });
   }
 
-  /**
-   * Load profile into the service
-   */
-  private loadProfile(userId: string): Observable<Profile> {
-    return this.getProfileByUserId(userId)
-      .pipe(
-        tap(profile => this.currentProfileSubject.next(profile))
-      );
-  }
+  isProfileComplete(profile: Profile): boolean {
+    const hasBasicInfo = !!(profile.firstName && profile.lastName && profile.email);
 
-  /**
-   * Get mock profile
-   */
-  private getMockProfile(userId: string): Observable<Profile> {
-    return new Observable(observer => {
-      setTimeout(() => {
-        const profile = this.mockProfiles.get(userId);
-        if (profile) {
-          observer.next(profile);
-          observer.complete();
-        } else {
-          observer.error({ message: 'Profile not found' });
-        }
-      }, 500);
-    });
-  }
-
-  /**
-   * Update mock profile
-   */
-  private updateMockProfile(updates: UpdateProfileRequest): Observable<Profile> {
-    const user = this.authService.currentUserValue;
-    if (!user) {
-      return throwError(() => new Error('User not authenticated'));
+    if (profile.role === 'CUSTOMER') {
+      const customerProfile = profile as CustomerProfile;
+      return hasBasicInfo && !!(customerProfile.company || customerProfile.industry);
+    } else {
+      const freelancerProfile = profile as FreelancerProfile;
+      return hasBasicInfo &&
+             !!(freelancerProfile.skills && freelancerProfile.skills.length > 0) &&
+             !!(freelancerProfile.title || freelancerProfile.hourlyRate);
     }
+  }
 
-    return new Observable(observer => {
-      setTimeout(() => {
-        const profile = this.mockProfiles.get(user.id);
-        if (profile) {
-          const updatedProfile = { ...profile, ...updates, updatedAt: new Date().toISOString() };
-          this.mockProfiles.set(user.id, updatedProfile);
-          observer.next(updatedProfile);
-          observer.complete();
-        } else {
-          observer.error({ message: 'Profile not found' });
-        }
-      }, 800);
-    });
+  private updateAuthUserProfile(profile: Profile): void {
+    const user = this.authService.currentUserValue;
+    if (user) {
+      this.authService.updateCurrentUser({
+        ...user,
+        profileCompleted: this.isProfileComplete(profile)
+      });
+    }
   }
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -55,6 +55,21 @@
       <mat-divider></mat-divider>
 
       <mat-nav-list>
+        <a mat-list-item
+           role="button"
+           tabindex="0"
+           [class.list-item-busy]="exportingData"
+           (click)="downloadMyData()"
+           (keydown.enter)="downloadMyData()"
+           aria-label="Download my data">
+          <mat-icon matListItemIcon>download</mat-icon>
+          <span matListItemTitle>Download My Data</span>
+          <span matListItemLine>Export a copy of all your personal information (POPIA)</span>
+          @if (exportingData) {
+            <mat-spinner matListItemMeta diameter="20"></mat-spinner>
+          }
+        </a>
+        <mat-divider></mat-divider>
         <a mat-list-item routerLink="/legal/popia-request">
           <mat-icon matListItemIcon>security</mat-icon>
           <span matListItemTitle>POPIA Data Request</span>

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -18,6 +18,17 @@
   mat-card-content {
     padding-top: 0.5rem;
   }
+
+  // "Download My Data" is an action item (no routerLink) — keep the affordance,
+  // and dim it while the export is in flight.
+  a[role='button'] {
+    cursor: pointer;
+
+    &.list-item-busy {
+      opacity: 0.6;
+      pointer-events: none;
+    }
+  }
 }
 
 .toggle-row {

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -9,6 +9,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatListModule } from '@angular/material/list';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { FormsModule } from '@angular/forms';
 import { LegalService } from '../legal/legal.service';
@@ -27,6 +28,7 @@ import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-acc
         MatListModule,
         MatSlideToggleModule,
         MatDialogModule,
+        MatProgressSpinnerModule,
         MatSnackBarModule
     ],
     templateUrl: './settings.component.html',
@@ -37,6 +39,7 @@ export class SettingsComponent implements OnInit {
   marketingLoading = false;
   canDelete = false;
   blockingReason = '';
+  exportingData = false;
 
   constructor(
     private legalService: LegalService,
@@ -81,6 +84,27 @@ export class SettingsComponent implements OnInit {
         this.marketingLoading = false;
         this.marketingConsented = !value; // revert
         this.snackBar.open('Failed to update preference.', 'OK', { duration: 3000 });
+      }
+    });
+  }
+
+  downloadMyData(): void {
+    if (this.exportingData) return;
+    this.exportingData = true;
+    this.legalService.exportMyData().subscribe({
+      next: (blob) => {
+        this.exportingData = false;
+        const url = window.URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = `freework-data-export-${new Date().toISOString().slice(0, 10)}.json`;
+        anchor.click();
+        window.URL.revokeObjectURL(url);
+        this.snackBar.open('Your data export has downloaded.', 'OK', { duration: 3000 });
+      },
+      error: () => {
+        this.exportingData = false;
+        this.snackBar.open('Failed to export your data. Please try again.', 'OK', { duration: 4000 });
       }
     });
   }


### PR DESCRIPTION
Retargeted to `staging` to land the latest frontend work **all together**:

- `feat(auth)`: resend verification email UI
- `feat(auth)`: forgot/reset password flow + pre-launch fixes
- `fix(websocket)`: auth via first-frame AUTH message (was `?token=`)
- `feat`: POPIA **Download My Data** export (Settings) + privacy-policy reconcile
- `fix`: ESLint no-useless-escape in reset-password regex
- `docs`: Cloudflare Pages Direct-Upload note

Triggers the GHA `Deploy → Staging` deploy. The red `Cloudflare Pages` check is the known dead Git-integration red herring (see CLAUDE.md) — not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)