### PR TITLE
feat(jobs): My Jobs all owned + lifecycle UI + ZAR currency

### DIFF
--- a/src/app/jobs/job-application/job-application.component.html
+++ b/src/app/jobs/job-application/job-application.component.html
@@ -31,7 +31,7 @@
               <mat-icon>attach_money</mat-icon>
               <div>
                 <span class="info-label">Budget</span>
-                <span class="info-value">${{ job.budget }} {{ job.budgetType === 'HOURLY' ? '/hr' : '' }}</span>
+                <span class="info-value">R{{ job.budget }} {{ job.budgetType === 'HOURLY' ? '/hr' : '' }}</span>
               </div>
             </div>
             <div class="info-item">

--- a/src/app/jobs/job-applications/job-applications.component.html
+++ b/src/app/jobs/job-applications/job-applications.component.html
@@ -43,7 +43,7 @@
         <div class="app-details">
           <div *ngIf="app.proposedRate" class="detail-item">
             <mat-icon>local_offer</mat-icon>
-            <strong>Proposed Rate:</strong> ${{ app.proposedRate }}
+            <strong>Proposed Rate:</strong> R{{ app.proposedRate }}
           </div>
           <div *ngIf="app.estimatedDuration" class="detail-item">
             <mat-icon>schedule</mat-icon>

--- a/src/app/jobs/job-detail/job-detail.component.html
+++ b/src/app/jobs/job-detail/job-detail.component.html
@@ -31,6 +31,10 @@
 
         <!-- Owner Actions -->
         <div class="action-buttons" *ngIf="isOwner">
+          <button mat-raised-button color="primary" *ngIf="canAcceptWork()" (click)="acceptWork()">
+            <mat-icon>task_alt</mat-icon>
+            Accept Work
+          </button>
           <button mat-raised-button color="primary" (click)="editJob()">
             <mat-icon>edit</mat-icon>
             Edit Job
@@ -43,7 +47,11 @@
 
         <!-- Freelancer Actions -->
         <div class="action-buttons" *ngIf="!isOwner">
-          <button mat-raised-button color="primary" (click)="applyForJob()">
+          <button mat-raised-button color="primary" *ngIf="canSubmitForReview()" (click)="submitForReview()">
+            <mat-icon>rate_review</mat-icon>
+            Submit for Review
+          </button>
+          <button mat-raised-button color="primary" *ngIf="job?.status === 'OPEN'" (click)="applyForJob()">
             <mat-icon>send</mat-icon>
             Apply Now
           </button>
@@ -251,7 +259,7 @@
           color="primary"
           class="apply-button"
           (click)="applyForJob()"
-          *ngIf="!isOwner">
+          *ngIf="!isOwner && job.status === 'OPEN'">
           <mat-icon>send</mat-icon>
           Apply Now
         </button>

--- a/src/app/jobs/job-detail/job-detail.component.ts
+++ b/src/app/jobs/job-detail/job-detail.component.ts
@@ -151,8 +151,9 @@ export class JobDetailComponent implements OnInit {
           this.showSuccess('Job deleted successfully');
           this.router.navigate(['/jobs']);
         },
-        error: () => {
-          this.showError('Failed to delete job');
+        error: (err) => {
+          // Backend blocks deleting in-progress/in-review jobs (#171) — surface its reason
+          this.showError(err?.error?.message || 'Failed to delete job');
         }
       });
     }
@@ -210,6 +211,7 @@ export class JobDetailComponent implements OnInit {
     const labels: Record<string, string> = {
       'OPEN': 'Open',
       'IN_PROGRESS': 'In Progress',
+      'REVIEW': 'In Review',
       'COMPLETED': 'Completed',
       'CANCELLED': 'Cancelled'
     };
@@ -220,10 +222,42 @@ export class JobDetailComponent implements OnInit {
     const colors: Record<string, string> = {
       'OPEN': 'primary',      // Blue - for open jobs
       'IN_PROGRESS': 'accent', // Green/Teal - for active work
+      'REVIEW': 'accent',      // awaiting customer acceptance
       'COMPLETED': 'warn',     // Orange/Amber - for finished jobs
       'CANCELLED': 'warn'      // Red - for cancelled jobs (changed from empty string)
     };
     return colors[status] || 'primary';
+  }
+
+  // ── Lifecycle actions (#167) ───────────────────────────────────────────────
+
+  /** Customer-only: accept the freelancer's submitted work (REVIEW → COMPLETED). */
+  canAcceptWork(): boolean {
+    return this.isOwner && this.job?.status === 'REVIEW';
+  }
+
+  /** Freelancer (assigned): submit work for the customer to review (IN_PROGRESS → REVIEW). */
+  canSubmitForReview(): boolean {
+    return !this.isOwner && this.job?.status === 'IN_PROGRESS';
+  }
+
+  submitForReview(): void {
+    this.changeStatus('REVIEW', 'Work submitted for review.');
+  }
+
+  acceptWork(): void {
+    this.changeStatus('COMPLETED', 'Work accepted — job marked complete.');
+  }
+
+  private changeStatus(status: string, successMsg: string): void {
+    if (!this.job) return;
+    this.jobService.updateJobStatus(this.job.id, status).subscribe({
+      next: (updated) => {
+        this.job = updated;
+        this.showSuccess(successMsg);
+      },
+      error: () => this.showError('Failed to update job status. Please try again.')
+    });
   }
 
   private showSuccess(message: string): void {

--- a/src/app/jobs/models/job.models.ts
+++ b/src/app/jobs/models/job.models.ts
@@ -11,7 +11,7 @@ export interface Job {
   location?: string;
   locationType?: 'REMOTE' | 'ONSITE' | 'HYBRID';
   skills?: string[];
-  status: 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+  status: 'OPEN' | 'IN_PROGRESS' | 'REVIEW' | 'COMPLETED' | 'CANCELLED';
   customerId?: string;
   customerName?: string;
   customerAvatar?: string;

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.html
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.html
@@ -117,7 +117,7 @@
               Your Rate
             </div>
             <div class="info-value">
-              ${{ activeJob.application.proposedRate }}{{ activeJob.job.budgetType === 'HOURLY' ? '/hr' : '' }}
+              R{{ activeJob.application.proposedRate }}{{ activeJob.job.budgetType === 'HOURLY' ? '/hr' : '' }}
             </div>
           </div>
 

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.ts
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.ts
@@ -74,13 +74,11 @@ export class MyActiveJobsComponent implements OnInit {
     this.loading = true;
     this.error = null;
 
-    // Get jobs posted by the customer that are in progress
+    // Show ALL jobs the customer has posted — a freshly-posted OPEN job with no
+    // applications yet must still appear here, otherwise the owner loses track of it (#168).
     this.jobService.getMyJobs().subscribe({
       next: (response) => {
-        // Filter for jobs that are in progress or have accepted applications
-        this.customerJobs = response.content.filter(
-          job => job.status === 'IN_PROGRESS' || (job.applicationsCount && job.applicationsCount > 0)
-        );
+        this.customerJobs = response.content;
         this.loading = false;
       },
       error: (error) => {
@@ -166,6 +164,7 @@ export class MyActiveJobsComponent implements OnInit {
     const colors: Record<string, string> = {
       'OPEN': 'primary',
       'IN_PROGRESS': 'accent',
+      'REVIEW': 'accent',
       'COMPLETED': 'warn',
       'CANCELLED': ''
     };
@@ -176,6 +175,7 @@ export class MyActiveJobsComponent implements OnInit {
     const labels: Record<string, string> = {
       'OPEN': 'Open',
       'IN_PROGRESS': 'In Progress',
+      'REVIEW': 'In Review',
       'COMPLETED': 'Completed',
       'CANCELLED': 'Cancelled'
     };
@@ -186,6 +186,7 @@ export class MyActiveJobsComponent implements OnInit {
     const icons: Record<string, string> = {
       'OPEN': 'radio_button_unchecked',
       'IN_PROGRESS': 'pending',
+      'REVIEW': 'rate_review',
       'COMPLETED': 'check_circle',
       'CANCELLED': 'cancel'
     };
@@ -193,9 +194,9 @@ export class MyActiveJobsComponent implements OnInit {
   }
 
   formatBudget(job: Job): string {
-    const amount = new Intl.NumberFormat('en-US', {
+    const amount = new Intl.NumberFormat('en-ZA', {
       style: 'currency',
-      currency: 'USD',
+      currency: 'ZAR',
       minimumFractionDigits: 0
     }).format(job.budget);
 
@@ -204,7 +205,7 @@ export class MyActiveJobsComponent implements OnInit {
 
   formatDate(date: Date | string | undefined): string {
     if (!date) return 'N/A';
-    return new Date(date).toLocaleDateString('en-US', {
+    return new Date(date).toLocaleDateString('en-ZA', {
       year: 'numeric',
       month: 'short',
       day: 'numeric'

--- a/src/app/jobs/my-applications/my-applications.component.html
+++ b/src/app/jobs/my-applications/my-applications.component.html
@@ -99,7 +99,7 @@
                 </span>
                 <span *ngIf="application.proposedRate" class="proposed-rate">
                   <mat-icon>attach_money</mat-icon>
-                  ${{ application.proposedRate }}
+                  R{{ application.proposedRate }}
                 </span>
               </p>
 

--- a/src/app/payments/payment-list/payment-list.component.html
+++ b/src/app/payments/payment-list/payment-list.component.html
@@ -36,7 +36,7 @@
           <mat-icon>attach_money</mat-icon>
           <div class="summary-info">
             <span class="label">Total Amount</span>
-            <span class="value">${{ getTotalAmount().toFixed(2) }}</span>
+            <span class="value">R{{ getTotalAmount().toFixed(2) }}</span>
           </div>
         </div>
       </div>
@@ -99,7 +99,7 @@
           </div>
 
           <div class="payment-amount">
-            <span class="amount">${{ payment.amount.toFixed(2) }}</span>
+            <span class="amount">R{{ payment.amount.toFixed(2) }}</span>
             <span class="currency">{{ payment.currency }}</span>
           </div>
 


### PR DESCRIPTION
Frontend half of the job-status cluster (pairs with backend #173).

- **#168** Customer My Jobs now lists ALL posted jobs (was hidden until an application/in-progress)
- **#167** Job-detail lifecycle controls: freelancer **Submit for Review** (IN_PROGRESS→REVIEW), customer **Accept Work** (REVIEW→COMPLETED); Apply Now only on OPEN; REVIEW added to status maps
- **#171** Surfaces the backend block message when deleting an active job
- **#61** Hardcoded `$`/USD replaced with ZAR (R) across job/application/payment views

Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)