### PR TITLE
fix(currency): remaining \$/USD on job & profile forms → ZAR (#61)

### DIFF
--- a/src/app/jobs/job-application/job-application.component.html
+++ b/src/app/jobs/job-application/job-application.component.html
@@ -176,7 +176,7 @@
                   type="number"
                   placeholder="0"
                 >
-                <span matPrefix>$&nbsp;</span>
+                <span matPrefix>R&nbsp;</span>
                 <span matSuffix *ngIf="job.budgetType === 'HOURLY'">/hr</span>
                 <mat-hint>Your rate for this project (optional)</mat-hint>
                 <mat-error *ngIf="applicationForm.get('proposedRate')?.hasError('min')">

--- a/src/app/jobs/job-form/job-form.component.html
+++ b/src/app/jobs/job-form/job-form.component.html
@@ -85,10 +85,10 @@
               formControlName="budget"
               placeholder="1000"
               min="1">
-            <span matTextPrefix>$&nbsp;</span>
+            <span matTextPrefix>R&nbsp;</span>
             <mat-icon matPrefix>attach_money</mat-icon>
             <mat-error *ngIf="f['budget'].hasError('required')">Budget is required</mat-error>
-            <mat-error *ngIf="f['budget'].hasError('min')">Budget must be at least $1</mat-error>
+            <mat-error *ngIf="f['budget'].hasError('min')">Budget must be at least R1</mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="outline" class="half-width">

--- a/src/app/profile/profile-setup/profile-setup.component.html
+++ b/src/app/profile/profile-setup/profile-setup.component.html
@@ -83,7 +83,7 @@
               </mat-form-field>
 
               <mat-form-field appearance="outline" class="half-width">
-                <mat-label>Hourly Rate (USD)</mat-label>
+                <mat-label>Hourly Rate (ZAR)</mat-label>
                 <mat-icon matPrefix>attach_money</mat-icon>
                 <input matInput type="number" formControlName="hourlyRate" placeholder="e.g. 50">
                 <mat-error *ngIf="setupForm.get('hourlyRate')?.hasError('required')">Hourly rate is required</mat-error>


### PR DESCRIPTION
Follow-up to #67. Fixes the \$/USD that slipped through on the job-form (budget input + min-error), job-application (proposed rate), and profile-setup (Hourly Rate label) — these used matPrefix/matTextPrefix so the first sweep missed them.