### PR TITLE
fix(currency): replace dollar (attach_money) icon with payments icon (#61)

### DIFF
--- a/src/app/jobs/job-application/job-application.component.html
+++ b/src/app/jobs/job-application/job-application.component.html
@@ -28,7 +28,7 @@
         <mat-card-content>
           <div class="job-info-grid">
             <div class="info-item">
-              <mat-icon>attach_money</mat-icon>
+              <mat-icon>payments</mat-icon>
               <div>
                 <span class="info-label">Budget</span>
                 <span class="info-value">R{{ job.budget }} {{ job.budgetType === 'HOURLY' ? '/hr' : '' }}</span>

--- a/src/app/jobs/job-form/job-form.component.html
+++ b/src/app/jobs/job-form/job-form.component.html
@@ -86,7 +86,7 @@
               placeholder="1000"
               min="1">
             <span matTextPrefix>R&nbsp;</span>
-            <mat-icon matPrefix>attach_money</mat-icon>
+            <mat-icon matPrefix>payments</mat-icon>
             <mat-error *ngIf="f['budget'].hasError('required')">Budget is required</mat-error>
             <mat-error *ngIf="f['budget'].hasError('min')">Budget must be at least R1</mat-error>
           </mat-form-field>

--- a/src/app/jobs/my-applications/my-applications.component.html
+++ b/src/app/jobs/my-applications/my-applications.component.html
@@ -98,7 +98,7 @@
                   Applied {{ getTimeAgo(application.appliedAt) }}
                 </span>
                 <span *ngIf="application.proposedRate" class="proposed-rate">
-                  <mat-icon>attach_money</mat-icon>
+                  <mat-icon>payments</mat-icon>
                   R{{ application.proposedRate }}
                 </span>
               </p>

--- a/src/app/payments/payment-list/payment-list.component.html
+++ b/src/app/payments/payment-list/payment-list.component.html
@@ -33,7 +33,7 @@
           </div>
         </div>
         <div class="summary-card total">
-          <mat-icon>attach_money</mat-icon>
+          <mat-icon>payments</mat-icon>
           <div class="summary-info">
             <span class="label">Total Amount</span>
             <span class="value">R{{ getTotalAmount().toFixed(2) }}</span>

--- a/src/app/profile/profile-setup/profile-setup.component.html
+++ b/src/app/profile/profile-setup/profile-setup.component.html
@@ -84,7 +84,7 @@
 
               <mat-form-field appearance="outline" class="half-width">
                 <mat-label>Hourly Rate (ZAR)</mat-label>
-                <mat-icon matPrefix>attach_money</mat-icon>
+                <mat-icon matPrefix>payments</mat-icon>
                 <input matInput type="number" formControlName="hourlyRate" placeholder="e.g. 50">
                 <mat-error *ngIf="setupForm.get('hourlyRate')?.hasError('required')">Hourly rate is required</mat-error>
                 <mat-error *ngIf="setupForm.get('hourlyRate')?.hasError('min')">Must be greater than 0</mat-error>


### PR DESCRIPTION
The real cause of the persistent dollar sign: Material's attach_money icon IS a dollar sign. Text prefixes were already R, but the dollar-sign ICON sat next to them on the budget input and 4 other currency spots. Swapped all 5 to the neutral payments icon.