### PR TITLE
Weave 2.0 — tiered visual elevation + theme-flash fix

### DIFF
--- a/src/app/jobs/job-list/job-list.component.html
+++ b/src/app/jobs/job-list/job-list.component.html
@@ -1,7 +1,7 @@
 <div class="job-list-container">
 
   <!-- Hero -->
-  <header class="jobs-hero">
+  <header class="jobs-hero aura-hero">
     <div class="jobs-hero__text">
       <span class="jobs-hero__eyebrow">
         <span class="live-dot" aria-hidden="true"></span>
@@ -14,6 +14,21 @@
         <h1>Find work you'll <em>love</em></h1>
         <p>Real projects from real clients across South Africa — and every rand you earn is yours. 0% commission, always.</p>
       }
+
+      <div class="hero-stats">
+        <div class="hero-stat">
+          <span class="hero-stat__num">{{ totalElements || 0 }}</span>
+          <span class="hero-stat__label">live {{ totalElements === 1 ? 'opportunity' : 'opportunities' }}</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat__num">0%</span>
+          <span class="hero-stat__label">commission, always</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat__num">100%</span>
+          <span class="hero-stat__label">yours to keep</span>
+        </div>
+      </div>
     </div>
     @if (isCustomer()) {
       <button

--- a/src/app/jobs/job-list/job-list.component.scss
+++ b/src/app/jobs/job-list/job-list.component.scss
@@ -14,27 +14,38 @@
 // HERO — editorial marketplace header
 // ════════════════════════════════════════════════
 .jobs-hero {
+  // Panel look (aurora bg, drifting orbs, padding, glass) comes from the
+  // global .aura-hero utility applied on this element — this file only adds
+  // the jobs-specific layout + typography on top.
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
   gap: var(--spacing-xl);
   margin-bottom: var(--spacing-2xl);
-  padding: var(--spacing-xl) 0 var(--spacing-2xl);
 
-  .jobs-hero__text {
-    max-width: 640px;
+  @media (max-width: 760px) {
+    flex-direction: column;
+    align-items: stretch;
   }
+
+  .jobs-hero__text { max-width: 680px; }
 
   .jobs-hero__eyebrow {
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-sm);
+    padding: 0.42rem 0.9rem;
+    border-radius: var(--radius-full);
     font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--color-accent-500);
-    margin-bottom: var(--spacing-md);
+    letter-spacing: 0.16em;
+    color: var(--color-accent-600);
+    background: rgba(43, 184, 138, 0.10);
+    border: 1px solid rgba(43, 184, 138, 0.28);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    margin-bottom: var(--spacing-lg);
   }
 
   .live-dot {
@@ -47,58 +58,87 @@
   }
 
   h1 {
-    font-size: clamp(2rem, 4.5vw, 3rem);
-    font-weight: 700;
-    letter-spacing: -0.035em;
-    line-height: 1.08;
-    margin: 0 0 var(--spacing-md);
+    font-size: clamp(2.6rem, 6.2vw, 5rem);
+    font-weight: 800;
+    letter-spacing: -0.045em;
+    line-height: 0.98;
+    margin: 0 0 var(--spacing-lg);
     color: var(--color-text-primary);
-
-    em {
-      font-family: 'Instrument Serif', Georgia, serif;
-      font-style: italic;
-      font-weight: 400;
-      background: linear-gradient(120deg, #2BB88A 0%, #1A8D6F 100%);
-      -webkit-background-clip: text;
-      background-clip: text;
-      -webkit-text-fill-color: transparent;
-      color: transparent;
-      padding-right: 0.06em; // keep the italic tail from clipping
-    }
+    // .aura-hero styles the <em> accent word (flowing gradient)
   }
 
   p {
     margin: 0;
     color: var(--color-text-secondary);
-    font-size: 15px;
-    line-height: 1.65;
-    max-width: 52ch;
+    font-size: clamp(15px, 1.4vw, 18px);
+    line-height: 1.6;
+    max-width: 54ch;
+  }
+
+  // Trust stat strip — marketplace social proof
+  .hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: clamp(1.5rem, 4vw, 3.25rem);
+    margin-top: clamp(1.75rem, 4vw, 2.75rem);
+    padding-top: var(--spacing-xl);
+    border-top: 1px solid var(--color-border);
+
+    .hero-stat {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+    }
+    .hero-stat__num {
+      font-family: 'Bricolage Grotesque', sans-serif;
+      font-size: clamp(1.6rem, 3vw, 2.25rem);
+      font-weight: 800;
+      letter-spacing: -0.035em;
+      line-height: 1;
+      background: linear-gradient(135deg, #2BB88A, #1A8D6F);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      color: transparent;
+    }
+    .hero-stat__label {
+      font-size: 11.5px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.09em;
+      color: var(--color-text-tertiary);
+    }
   }
 
   .post-job-btn {
-    height: 44px;
-    padding: 0 var(--spacing-xl);
-    font-size: 14px;
-    font-weight: 600;
+    height: 52px;
+    padding: 0 var(--spacing-2xl);
+    font-size: 15px;
+    font-weight: 700;
     border-radius: var(--radius-full);
     background: linear-gradient(135deg, #2BB88A 0%, #1A8D6F 100%) !important;
     color: #fff !important;
-    box-shadow: 0 4px 14px rgba(43, 184, 138, 0.35);
-    transition: all var(--transition-fast);
+    box-shadow: 0 10px 30px rgba(43, 184, 138, 0.45);
+    transition: all var(--transition-base);
     flex-shrink: 0;
 
     &:hover {
-      box-shadow: 0 6px 20px rgba(43, 184, 138, 0.45);
-      transform: translateY(-1px);
+      box-shadow: 0 14px 40px rgba(43, 184, 138, 0.55);
+      transform: translateY(-2px);
     }
 
     mat-icon {
       margin-right: var(--spacing-xs);
-      font-size: 1.125rem;
-      width: 1.125rem;
-      height: 1.125rem;
+      font-size: 1.25rem;
+      width: 1.25rem;
+      height: 1.25rem;
     }
   }
+}
+
+@keyframes card-enter {
+  from { opacity: 0; transform: translateY(20px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
 }
 
 @keyframes live-pulse {
@@ -116,7 +156,10 @@
   border-radius: var(--radius-2xl);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  background: color-mix(in srgb, var(--color-surface) 78%, transparent);
+  backdrop-filter: blur(18px) saturate(160%);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+  box-shadow: var(--shadow-md);
 
   // Uniform form field sizing — no subscript space, consistent 48px height
   ::ng-deep .mat-mdc-form-field {
@@ -475,6 +518,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
+  animation: card-enter 0.5s var(--ease-out-quart, cubic-bezier(0.25, 1, 0.5, 1)) both;
 
   // Accent line that draws in on hover
   &::after {
@@ -488,18 +532,33 @@
     transform: scaleX(0);
     transform-origin: left;
     transition: transform var(--transition-slow);
+    z-index: 1;
   }
 
   &:hover {
-    transform: translateY(-3px);
+    transform: translateY(-6px);
+    box-shadow:
+      0 24px 60px -16px rgba(43, 184, 138, 0.55),
+      0 0 0 1px rgba(43, 184, 138, 0.35) !important;
 
     &::after { transform: scaleX(1); }
 
     .job-card-icon {
       background: linear-gradient(135deg, #2BB88A 0%, #1A8D6F 100%);
+      border-color: transparent;
+      box-shadow: 0 6px 16px rgba(43, 184, 138, 0.4);
+      transform: scale(1.06) rotate(-3deg);
       mat-icon { color: #fff; }
     }
   }
+
+  // Staggered entrance for the first row(s)
+  &:nth-child(1) { animation-delay: 40ms; }
+  &:nth-child(2) { animation-delay: 90ms; }
+  &:nth-child(3) { animation-delay: 140ms; }
+  &:nth-child(4) { animation-delay: 190ms; }
+  &:nth-child(5) { animation-delay: 240ms; }
+  &:nth-child(6) { animation-delay: 290ms; }
 
   &:focus-visible {
     outline: 2px solid var(--color-accent-500);

--- a/src/app/profile/profile-view/profile-view.component.html
+++ b/src/app/profile/profile-view/profile-view.component.html
@@ -69,7 +69,7 @@
     <div class="profile-content">
 
       <!-- Hero Header -->
-      <header class="profile-hero">
+      <header class="profile-hero aura-hero">
         <span class="profile-eyebrow">
           <span class="live-dot" aria-hidden="true"></span>
           freework profile

--- a/src/app/subscription/pricing/pricing.component.html
+++ b/src/app/subscription/pricing/pricing.component.html
@@ -3,8 +3,8 @@
 <div class="pricing-page">
 
   <!-- Hero -->
-  <div class="pricing-hero">
-    <h1>Simple, honest pricing</h1>
+  <div class="pricing-hero aura-hero aura-hero--gold">
+    <h1>Simple, <em>honest</em> pricing</h1>
     <p class="hero-sub">
       Unlike Upwork or Fiverr — Freework <strong>never takes a cut</strong> of your earnings.
       Upgrading just unlocks the full platform.

--- a/src/app/subscription/pricing/pricing.component.scss
+++ b/src/app/subscription/pricing/pricing.component.scss
@@ -25,9 +25,9 @@
   .commission-badge {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 8px 18px;
-    border-radius: 24px;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--radius-full);
     background: var(--color-accent-50);
     color: var(--color-accent-700);
     font-weight: 600;
@@ -42,10 +42,10 @@
 .plans-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 24px;
+  gap: var(--spacing-lg);
   max-width: 1100px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 var(--spacing-lg);
 
   @media (max-width: 900px) {
     grid-template-columns: 1fr 1fr;
@@ -58,15 +58,15 @@
 
 .plan-card {
   position: relative;
-  border-radius: 16px !important;
+  border-radius: var(--radius-xl) !important;
   overflow: visible;
 
   mat-card-header { padding-bottom: 0; }
 
-  mat-card-content { padding-top: 16px; }
+  mat-card-content { padding-top: var(--spacing-md); }
 
   mat-card-actions {
-    padding: 8px 16px 20px;
+    padding: var(--spacing-sm) var(--spacing-md) var(--spacing-lg);
     display: flex;
     justify-content: center;
   }
@@ -81,9 +81,9 @@
 .plan-badge {
   position: absolute;
   top: -12px;
-  right: 16px;
-  padding: 4px 12px;
-  border-radius: 12px;
+  right: var(--spacing-md);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-lg);
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -131,8 +131,8 @@
 .plan-price {
   display: flex;
   align-items: baseline;
-  gap: 4px;
-  margin: 8px 0 20px;
+  gap: var(--spacing-xs);
+  margin: var(--spacing-sm) 0 var(--spacing-lg);
 
   .price-amount {
     font-size: 36px;
@@ -198,18 +198,18 @@
 // Commission callout
 .callout-section {
   max-width: 1100px;
-  margin: 32px auto 0;
-  padding: 0 24px;
+  margin: var(--spacing-xl) auto 0;
+  padding: 0 var(--spacing-lg);
 }
 
 .commission-callout {
-  border-radius: 16px !important;
+  border-radius: var(--radius-xl) !important;
 }
 
 .callout-inner {
   display: flex;
   align-items: flex-start;
-  gap: 20px;
+  gap: var(--spacing-lg);
 
   .callout-icon {
     font-size: 40px;

--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -32,6 +32,10 @@ export class ThemeService {
   }
 
   private applyTheme(theme: Theme): void {
-    document.documentElement.setAttribute('data-theme', theme);
+    const el = document.documentElement;
+    el.setAttribute('data-theme', theme);
+    // Keep the root background in sync with the pre-paint value set in index.html,
+    // so toggling never leaves a stale colour behind body (e.g. overscroll areas).
+    el.style.backgroundColor = theme === 'light' ? '#F7F6F3' : '#0D1F1A';
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,10 +1,30 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8">
   <title>freework — doing what you love</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Set the theme before first paint — kills the flash of the wrong theme (FOUC).
+       Must run in <head>, before <body> renders. Mirrors ThemeService.resolveInitialTheme(). -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('freework_theme');
+        if (t !== 'dark' && t !== 'light') {
+          t = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        var el = document.documentElement;
+        el.setAttribute('data-theme', t);
+        el.style.backgroundColor = (t === 'light') ? '#F7F6F3' : '#0D1F1A';
+      } catch (e) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        document.documentElement.style.backgroundColor = '#0D1F1A';
+      }
+    })();
+  </script>
+
   <meta name="description" content="freework — share your skill with the world. Photography, development, design, writing — whatever you do best, someone out there needs it.">
   <meta name="theme-color" content="#0f1f1a">
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -321,15 +321,18 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: -0.02em;
   color: var(--color-text-primary);
   margin: 0;
-  line-height: 1.3;
+  line-height: 1.25;
+  font-optical-sizing: auto;
+  text-wrap: balance; // avoid orphan words on headings (modern browsers)
 }
 
-h1 { font-size: 2rem;     font-weight: 700; letter-spacing: -0.025em; }
-h2 { font-size: 1.625rem; }
-h3 { font-size: 1.375rem; }
-h4 { font-size: 1.125rem; }
+// Fluid, optically-sized scale — display headings tighten tracking as they grow
+h1 { font-size: clamp(1.9rem, 1.35rem + 2.1vw, 2.55rem); font-weight: 700; letter-spacing: -0.035em; font-variation-settings: 'opsz' 40; }
+h2 { font-size: clamp(1.5rem, 1.2rem + 1.15vw, 1.9rem);  letter-spacing: -0.028em; font-variation-settings: 'opsz' 32; }
+h3 { font-size: clamp(1.2rem, 1.08rem + 0.5vw, 1.45rem); letter-spacing: -0.02em; }
+h4 { font-size: 1.125rem; letter-spacing: -0.015em; }
 h5 { font-size: 1rem;     font-weight: 600; }
-h6 { font-size: 0.875rem; font-weight: 600; }
+h6 { font-size: 0.875rem;  font-weight: 600; }
 
 p {
   margin: 0;
@@ -819,3 +822,217 @@ a {
     scroll-behavior: auto !important;
   }
 }
+
+// ════════════════════════════════════════════════════════════
+// THE WEAVE 2.0 — elevation · motion · texture
+// Appended so it refines the base system above. Additive by design.
+// ════════════════════════════════════════════════════════════
+
+:root {
+  // Expressive easing + a motion duration scale
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-spring:    cubic-bezier(0.34, 1.4, 0.5, 1);
+  --dur-1: 140ms;
+  --dur-2: 240ms;
+  --dur-3: 440ms;
+}
+
+// ── Premium print-grain: a barely-there texture over the ambient wash ──
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  mix-blend-mode: overlay;
+}
+[data-theme="light"] body::before { opacity: 0.022; }
+app-root { position: relative; z-index: 1; }
+
+// Cards keep a positioning context for their own badges/ribbons.
+.mat-mdc-card { position: relative; }
+
+// ── Unify primary CTAs on the brand gradient + a light sheen sweep on hover ──
+.mat-mdc-raised-button.mat-primary,
+.mat-mdc-unelevated-button.mat-primary {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #2BB88A 0%, #1A8D6F 100%) !important;
+  color: #fff !important;
+  box-shadow: 0 4px 14px rgba(43, 184, 138, 0.30) !important;
+  transition: box-shadow var(--dur-2) var(--ease-out-quart), transform var(--dur-1) var(--ease-spring) !important;
+
+  &:hover {
+    box-shadow: 0 8px 22px rgba(43, 184, 138, 0.42) !important;
+    transform: translateY(-1px);
+  }
+  &:active { transform: translateY(0); }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -40%;
+    width: 40%;
+    height: 100%;
+    background: linear-gradient(100deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+    transform: skewX(-18deg);
+    pointer-events: none;
+    opacity: 0;
+  }
+  &:hover::after { animation: weave-sheen var(--dur-3) var(--ease-out-quart); }
+}
+
+@keyframes weave-sheen {
+  0%   { opacity: 0; left: -40%; }
+  25%  { opacity: 1; }
+  100% { opacity: 0; left: 130%; }
+}
+
+// ── Form fields: soft focus glow (premium, guides the eye) ──
+.mat-mdc-form-field.mat-focused .mat-mdc-form-field-flex {
+  box-shadow: 0 0 0 4px rgba(43, 184, 138, 0.12);
+  transition: box-shadow var(--dur-2) var(--ease-out-quart);
+}
+
+// ── Editorial hero entrance: one focal reveal per view, gently staggered ──
+@keyframes weave-rise {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: none; }
+}
+.jobs-hero__eyebrow, .page-hero__eyebrow, .profile-eyebrow,
+.jobs-hero h1, .page-hero h1, .profile-hero h1, .plan-title,
+.jobs-hero p, .page-hero p {
+  animation: weave-rise var(--dur-3) var(--ease-out-quart) both;
+}
+.jobs-hero h1, .page-hero h1, .profile-hero h1, .plan-title { animation-delay: 70ms; }
+.jobs-hero p, .page-hero p { animation-delay: 140ms; }
+
+// ── Brand scrollbar ──
+* { scrollbar-width: thin; scrollbar-color: var(--color-gray-400) transparent; }
+::-webkit-scrollbar { width: 11px; height: 11px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: var(--color-gray-300);
+  border-radius: var(--radius-full);
+  border: 3px solid transparent;
+  background-clip: padding-box;
+  transition: background var(--transition-fast);
+}
+::-webkit-scrollbar-thumb:hover { background: var(--color-accent-500); background-clip: padding-box; }
+
+// ── Brand text selection ──
+::selection { background: rgba(43, 184, 138, 0.24); color: var(--color-text-primary); }
+
+// ── Refined focus ring: crisp outline + soft brand halo ──
+:focus-visible {
+  outline: 2px solid var(--color-accent-500);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(43, 184, 138, 0.15);
+  border-radius: var(--radius-sm);
+}
+
+// ── Reduced-motion: silence the new expressive motion ──
+@media (prefers-reduced-motion: reduce) {
+  .mat-mdc-raised-button.mat-primary:hover::after,
+  .mat-mdc-unelevated-button.mat-primary:hover::after { animation: none; }
+  .jobs-hero__eyebrow, .page-hero__eyebrow, .profile-eyebrow,
+  .jobs-hero h1, .page-hero h1, .profile-hero h1, .plan-title,
+  .jobs-hero p, .page-hero p { animation: none !important; }
+}
+
+// ════════════════════════════════════════════════════════════
+// THE WEAVE 2.0 — cascade primitives (cards + aurora heroes)
+// ════════════════════════════════════════════════════════════
+
+// ── Every card comes alive: spring lift + brand glow on hover ──
+.mat-mdc-card {
+  transition:
+    transform var(--dur-2) var(--ease-spring),
+    box-shadow var(--dur-2) var(--ease-out-quart),
+    background var(--transition-base),
+    border-color var(--transition-base) !important;
+}
+[data-theme="dark"] .mat-mdc-card:hover {
+  transform: translateY(-3px);
+  box-shadow:
+    0 20px 48px -16px rgba(0, 0, 0, 0.62),
+    0 14px 40px -20px rgba(43, 184, 138, 0.55),
+    0 0 0 1px rgba(43, 184, 138, 0.16) !important;
+}
+[data-theme="light"] .mat-mdc-card:hover {
+  transform: translateY(-3px);
+  box-shadow:
+    0 20px 46px -18px rgba(26, 141, 111, 0.30),
+    0 0 0 1px rgba(43, 184, 138, 0.22) !important;
+}
+
+// ── Aurora hero — opt-in showpiece panel for any page's header ──
+.aura-hero {
+  position: relative !important;
+  isolation: isolate;
+  overflow: hidden !important;
+  max-width: none !important;
+  width: 100%;
+  border-radius: var(--radius-3xl) !important;
+  border: 1px solid var(--color-border) !important;
+  padding: clamp(2.25rem, 5vw, 4.5rem) clamp(1.5rem, 4vw, 3.5rem) !important;
+  box-shadow: var(--shadow-lg);
+  background:
+    radial-gradient(ellipse 90% 70% at 12% 6%,   rgba(43, 184, 138, 0.26), transparent 58%),
+    radial-gradient(ellipse 70% 60% at 92% 16%,  rgba(20, 112, 90, 0.30),  transparent 55%),
+    radial-gradient(ellipse 80% 75% at 62% 120%, rgba(43, 184, 138, 0.18), transparent 60%),
+    var(--color-surface) !important;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    z-index: -1;
+    border-radius: 50%;
+    filter: blur(64px);
+    pointer-events: none;
+  }
+  // Static glow orbs — depth without perpetual motion (research: continuous
+  // decorative animation is an anti-pattern and taxes low-end devices).
+  &::before {
+    width: 380px; height: 380px; top: -130px; right: -50px;
+    background: radial-gradient(circle, rgba(43, 184, 138, 0.34), transparent 70%);
+  }
+  &::after {
+    width: 320px; height: 320px; bottom: -150px; left: -40px;
+    background: radial-gradient(circle, rgba(20, 141, 111, 0.30), transparent 70%);
+  }
+
+  // Serif accent word — static brand gradient (self-styling so any page inherits it)
+  h1 em, h2 em {
+    font-family: 'Instrument Serif', Georgia, serif;
+    font-style: italic;
+    font-weight: 400;
+    background: linear-gradient(115deg, #2BB88A 0%, #1A8D6F 60%, #14705A 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+  }
+
+  // ── Hue variants — same language, different mood (non-uniform flow) ──
+  &--gold {
+    background:
+      radial-gradient(ellipse 90% 70% at 12% 6%,   rgba(245, 176, 65, 0.18), transparent 58%),
+      radial-gradient(ellipse 70% 60% at 92% 16%,  rgba(20, 141, 111, 0.28), transparent 55%),
+      radial-gradient(ellipse 80% 75% at 62% 120%, rgba(43, 184, 138, 0.16), transparent 60%),
+      var(--color-surface) !important;
+    &::before { background: radial-gradient(circle, rgba(245, 176, 65, 0.30), transparent 70%); }
+  }
+  &--deep {
+    background:
+      radial-gradient(ellipse 90% 70% at 12% 6%,   rgba(20, 112, 90, 0.34),  transparent 58%),
+      radial-gradient(ellipse 70% 60% at 92% 16%,  rgba(43, 184, 138, 0.22), transparent 55%),
+      radial-gradient(ellipse 80% 75% at 62% 120%, rgba(20, 141, 111, 0.20), transparent 60%),
+      var(--color-surface) !important;
+  }
+}
+


### PR DESCRIPTION
## Weave 2.0 — tiered visual elevation (+ theme-flash fix)

Deploys the elevated look to staging. **Research-driven tiering**: expressive on the surfaces that convert, calm/fast where people work — because continuous decorative motion is a flagged anti-pattern and taxes low-end devices (a concern for this audience).

### Global system (`styles.scss`)
- Fluid, optically-sized type scale; refined focus ring, brand scrollbar, text selection; subtle print grain.
- **Every card**: spring lift + brand glow on hover (interaction-only, no perpetual motion).
- Primary CTAs unified on the brand gradient with a hover sheen.
- `.aura-hero` utility — a **static** aurora panel + glow with hue variants (teal / gold / deep-pine).

### Tiering
- **Expressive** (aurora heroes): jobs, pricing, profile showcase.
- **Calm** (static, scannable headers): all authenticated working pages — dashboards, applications, payments, settings.
- **No perpetual animation anywhere** — motion is entrance + interaction only.

### Fixes in this PR
- **Theme flash (FOUC)** on load — theme is now set synchronously in `<head>` before first paint (localStorage → OS pref → dark).
- Removed the card top **edge-light hairline** that read as a stray line on cards.
- **Tokenised pricing spacing** onto the `--spacing-*` / `--radius-*` scale (was raw px).

### Verification
- `eslint src/app` — 0 errors (74 pre-existing staging warnings).
- Production build passes (enforced by the pre-commit hook on both commits).
- Works in dark + light; `prefers-reduced-motion` honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)