### PR TITLE
fix: wire up job status progression (submit-for-review → complete)

### DIFF
--- a/src/app/jobs/job-detail/job-detail.component.html
+++ b/src/app/jobs/job-detail/job-detail.component.html
@@ -31,6 +31,16 @@
 
         <!-- Owner Actions -->
         <div class="action-buttons" *ngIf="isOwner">
+          @if (isInReview()) {
+            <button mat-raised-button color="primary" (click)="markAsCompleted()">
+              <mat-icon>check_circle</mat-icon>
+              Mark as Completed
+            </button>
+            <button mat-stroked-button (click)="requestChanges()">
+              <mat-icon>undo</mat-icon>
+              Request Changes
+            </button>
+          }
           <button mat-raised-button color="primary" (click)="editJob()">
             <mat-icon>edit</mat-icon>
             Edit Job

--- a/src/app/jobs/job-detail/job-detail.component.ts
+++ b/src/app/jobs/job-detail/job-detail.component.ts
@@ -204,6 +204,7 @@ export class JobDetailComponent implements OnInit {
     const labels: Record<string, string> = {
       'OPEN': 'Open',
       'IN_PROGRESS': 'In Progress',
+      'REVIEW': 'In Review',
       'COMPLETED': 'Completed',
       'CANCELLED': 'Cancelled'
     };
@@ -214,10 +215,48 @@ export class JobDetailComponent implements OnInit {
     const colors: Record<string, string> = {
       'OPEN': 'primary',      // Blue - for open jobs
       'IN_PROGRESS': 'accent', // Green/Teal - for active work
+      'REVIEW': 'accent',      // Awaiting customer approval
       'COMPLETED': 'warn',     // Orange/Amber - for finished jobs
       'CANCELLED': 'warn'      // Red - for cancelled jobs (changed from empty string)
     };
     return colors[status] || 'primary';
+  }
+
+  isInReview(): boolean {
+    return this.job?.status === 'REVIEW';
+  }
+
+  markAsCompleted(): void {
+    if (!this.job) return;
+
+    const confirmed = confirm('Accept this work and mark the job as completed? This confirms the freelancer has delivered.');
+    if (!confirmed) return;
+
+    this.jobService.updateJobStatus(this.job.id, 'COMPLETED').subscribe({
+      next: (job) => {
+        this.job = job;
+        this.showSuccess('Job marked as completed. You can now leave a review.');
+      },
+      error: (error) => {
+        console.error('Error completing job:', error);
+        this.showError('Could not mark the job as completed. Please try again.');
+      }
+    });
+  }
+
+  requestChanges(): void {
+    if (!this.job) return;
+
+    this.jobService.updateJobStatus(this.job.id, 'IN_PROGRESS').subscribe({
+      next: (job) => {
+        this.job = job;
+        this.showSuccess('Sent back to the freelancer for changes.');
+      },
+      error: (error) => {
+        console.error('Error requesting changes:', error);
+        this.showError('Could not send the job back for changes. Please try again.');
+      }
+    });
   }
 
   private showSuccess(message: string): void {

--- a/src/app/jobs/models/job.models.ts
+++ b/src/app/jobs/models/job.models.ts
@@ -11,7 +11,7 @@ export interface Job {
   location?: string;
   locationType?: 'REMOTE' | 'ONSITE' | 'HYBRID';
   skills?: string[];
-  status: 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+  status: 'OPEN' | 'IN_PROGRESS' | 'REVIEW' | 'COMPLETED' | 'CANCELLED';
   customerId?: string;
   customerName?: string;
   customerAvatar?: string;

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.html
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.html
@@ -192,6 +192,18 @@
           <mat-icon>chat</mat-icon>
           Message Client
         </button>
+        @if (activeJob.job.status === 'IN_PROGRESS') {
+          <button mat-raised-button color="primary" (click)="submitForReview(activeJob)">
+            <mat-icon>rate_review</mat-icon>
+            Submit for Review
+          </button>
+        }
+        @if (activeJob.job.status === 'REVIEW') {
+          <span class="awaiting-approval">
+            <mat-icon>hourglass_top</mat-icon>
+            Awaiting client approval
+          </span>
+        }
         <button mat-button *ngIf="activeJob.job.status === 'COMPLETED'" (click)="writeReview(activeJob)">
           <mat-icon>rate_review</mat-icon>
           Write Review

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.scss
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.scss
@@ -485,3 +485,19 @@
     }
   }
 }
+
+.awaiting-approval {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 0 var(--spacing-sm);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--mat-sys-tertiary, #6a5acd);
+
+  mat-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+}

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.ts
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.ts
@@ -77,9 +77,9 @@ export class MyActiveJobsComponent implements OnInit {
     // Get jobs posted by the customer that are in progress
     this.jobService.getMyJobs().subscribe({
       next: (response) => {
-        // Filter for jobs that are in progress or have accepted applications
+        // Filter for jobs that are in progress, awaiting review, or have accepted applications
         this.customerJobs = response.content.filter(
-          job => job.status === 'IN_PROGRESS' || (job.applicationsCount && job.applicationsCount > 0)
+          job => job.status === 'IN_PROGRESS' || job.status === 'REVIEW' || (job.applicationsCount && job.applicationsCount > 0)
         );
         this.loading = false;
       },
@@ -166,6 +166,7 @@ export class MyActiveJobsComponent implements OnInit {
     const colors: Record<string, string> = {
       'OPEN': 'primary',
       'IN_PROGRESS': 'accent',
+      'REVIEW': 'accent',
       'COMPLETED': 'warn',
       'CANCELLED': ''
     };
@@ -176,6 +177,7 @@ export class MyActiveJobsComponent implements OnInit {
     const labels: Record<string, string> = {
       'OPEN': 'Open',
       'IN_PROGRESS': 'In Progress',
+      'REVIEW': 'In Review',
       'COMPLETED': 'Completed',
       'CANCELLED': 'Cancelled'
     };
@@ -186,6 +188,7 @@ export class MyActiveJobsComponent implements OnInit {
     const icons: Record<string, string> = {
       'OPEN': 'radio_button_unchecked',
       'IN_PROGRESS': 'pending',
+      'REVIEW': 'rate_review',
       'COMPLETED': 'check_circle',
       'CANCELLED': 'cancel'
     };
@@ -232,6 +235,19 @@ export class MyActiveJobsComponent implements OnInit {
     });
   }
 
+  submitForReview(activeJob: ActiveJob): void {
+    this.jobService.updateJobStatus(activeJob.job.id, 'REVIEW').subscribe({
+      next: (job) => {
+        activeJob.job.status = job.status;
+        this.showSuccess('Work submitted for review. The client has been asked to approve it.');
+      },
+      error: (error) => {
+        console.error('Error submitting job for review:', error);
+        this.showError('Could not submit your work for review. Please try again.');
+      }
+    });
+  }
+
   writeReview(activeJob: ActiveJob): void {
     const dialogData: ReviewDialogData = {
       jobId: activeJob.job.id,
@@ -263,6 +279,15 @@ export class MyActiveJobsComponent implements OnInit {
       horizontalPosition: 'end',
       verticalPosition: 'top',
       panelClass: ['success-snackbar']
+    });
+  }
+
+  private showError(message: string): void {
+    this.snackBar.open(message, 'Close', {
+      duration: 5000,
+      horizontalPosition: 'end',
+      verticalPosition: 'top',
+      panelClass: ['error-snackbar']
     });
   }
 }


### PR DESCRIPTION
The job status state machine existed in the backend but had no UI. Once a job hit IN_PROGRESS (auto, on application accept) neither party could move it forward: updateJobStatus() had zero callers and REVIEW was missing from the frontend Job.status union entirely.

- Add REVIEW to the Job.status type and to status colour/label/icon maps
- Freelancer: "Submit for Review" button (IN_PROGRESS → REVIEW) in My Active Jobs, with an "awaiting client approval" note afterwards
- Customer: "Mark as Completed" (REVIEW → COMPLETED) and "Request Changes" (REVIEW → IN_PROGRESS) actions in Job Detail
- Keep REVIEW jobs on the customer's active-jobs list

No backend change: the API already authorises these transitions.