### PR TITLE
fix: wire up job status progression buttons (submit-for-review → comp…

### DIFF
--- a/src/app/jobs/job-detail/job-detail.component.html
+++ b/src/app/jobs/job-detail/job-detail.component.html
@@ -35,6 +35,18 @@
         <!-- Owner Actions -->
         @if (isOwner) {
 <div class="action-buttons">
+          @if (canAcceptWork()) {
+            <button mat-raised-button color="primary" (click)="acceptWork()">
+              <mat-icon>check_circle</mat-icon>
+              Mark as Completed
+            </button>
+          }
+          @if (canRequestChanges()) {
+            <button mat-stroked-button (click)="requestChanges()">
+              <mat-icon>undo</mat-icon>
+              Request Changes
+            </button>
+          }
           <button mat-raised-button color="primary" (click)="editJob()">
             <mat-icon>edit</mat-icon>
             Edit Job
@@ -49,6 +61,12 @@
         <!-- Freelancer Actions -->
         @if (!isOwner) {
 <div class="action-buttons">
+          @if (canSubmitForReview()) {
+            <button mat-raised-button color="primary" (click)="submitForReview()">
+              <mat-icon>rate_review</mat-icon>
+              Submit for Review
+            </button>
+          }
           <button mat-raised-button color="primary" (click)="applyForJob()">
             <mat-icon>send</mat-icon>
             Apply Now

--- a/src/app/jobs/job-detail/job-detail.component.ts
+++ b/src/app/jobs/job-detail/job-detail.component.ts
@@ -235,12 +235,21 @@ export class JobDetailComponent implements OnInit {
     return !this.isOwner && this.job?.status === 'IN_PROGRESS';
   }
 
+  /** Customer-only: send submitted work back to the freelancer (REVIEW → IN_PROGRESS). */
+  canRequestChanges(): boolean {
+    return this.isOwner && this.job?.status === 'REVIEW';
+  }
+
   submitForReview(): void {
     this.changeStatus('REVIEW', 'Work submitted for review.');
   }
 
   acceptWork(): void {
     this.changeStatus('COMPLETED', 'Work accepted — job marked complete.');
+  }
+
+  requestChanges(): void {
+    this.changeStatus('IN_PROGRESS', 'Sent back to the freelancer for changes.');
   }
 
   private changeStatus(status: string, successMsg: string): void {

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.html
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.html
@@ -216,6 +216,18 @@
           Message Client
         </button>
 }
+        @if (activeJob.job.status === 'IN_PROGRESS') {
+          <button mat-raised-button color="primary" (click)="submitForReview(activeJob)">
+            <mat-icon>rate_review</mat-icon>
+            Submit for Review
+          </button>
+        }
+        @if (activeJob.job.status === 'REVIEW') {
+          <span class="awaiting-approval">
+            <mat-icon>hourglass_top</mat-icon>
+            Awaiting client approval
+          </span>
+        }
         @if (activeJob.job.status === 'COMPLETED') {
 <button mat-button (click)="writeReview(activeJob)">
           <mat-icon>rate_review</mat-icon>

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.scss
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.scss
@@ -477,3 +477,19 @@
   color: var(--chip-status-withdrawn-color);
   border: 1px solid var(--chip-status-withdrawn-border);
 }
+
+.awaiting-approval {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 0 var(--spacing-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-accent-600);
+
+  mat-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+}

--- a/src/app/jobs/my-active-jobs/my-active-jobs.component.ts
+++ b/src/app/jobs/my-active-jobs/my-active-jobs.component.ts
@@ -227,6 +227,20 @@ export class MyActiveJobsComponent implements OnInit {
     });
   }
 
+  /** Freelancer (assigned): submit work for the customer to review (IN_PROGRESS → REVIEW). */
+  submitForReview(activeJob: ActiveJob): void {
+    this.jobService.updateJobStatus(activeJob.job.id, 'REVIEW').subscribe({
+      next: (job) => {
+        activeJob.job.status = job.status;
+        this.showSuccess('Work submitted for review. The client has been asked to approve it.');
+      },
+      error: (error) => {
+        console.error('Error submitting job for review:', error);
+        this.showError('Could not submit your work for review. Please try again.');
+      }
+    });
+  }
+
   writeReview(activeJob: ActiveJob): void {
     const dialogData: ReviewDialogData = {
       jobId: activeJob.job.id,
@@ -258,6 +272,15 @@ export class MyActiveJobsComponent implements OnInit {
       horizontalPosition: 'end',
       verticalPosition: 'top',
       panelClass: ['success-snackbar']
+    });
+  }
+
+  private showError(message: string): void {
+    this.snackBar.open(message, 'Close', {
+      duration: 5000,
+      horizontalPosition: 'end',
+      verticalPosition: 'top',
+      panelClass: ['error-snackbar']
     });
   }
 }


### PR DESCRIPTION
…lete)

The lifecycle methods from #67 (submitForReview/acceptWork/canSubmitForReview/ canAcceptWork) existed in job-detail but were never rendered — no button called them — so on staging a freelancer still couldn't move a job out of IN_PROGRESS.

- job-detail: render "Submit for Review" (freelancer, IN_PROGRESS → REVIEW), "Mark as Completed" (owner, REVIEW → COMPLETED) and "Request Changes" (owner, REVIEW → IN_PROGRESS); add canRequestChanges() + requestChanges()
- my-active-jobs: add freelancer "Submit for Review" button + submitForReview(), an "awaiting client approval" note in REVIEW, and a showError() helper

Styling follows The Weave; no backend change (API already authorises these).