### PR TITLE
fix: footer flows with page content instead of squatting on the viewport

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -225,11 +225,12 @@
         </div>
       </mat-toolbar>
 
-      <!-- Main Content -->
+      <!-- Main Content — footer lives inside the scroll region so it's reached
+           by scrolling instead of permanently occupying viewport height -->
       <main class="main-content">
         <router-outlet></router-outlet>
+        <app-footer></app-footer>
       </main>
-      <app-footer></app-footer>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -353,10 +353,20 @@ mat-nav-list {
 }
 
 // ── Main content area ─────────────────────────────
+// Flex column so the in-flow footer (margin-top: auto) sits at the bottom edge
+// on short pages and after the content — below the fold — on long ones.
+// Routed components keep their bounded height: percentage heights still resolve
+// because .main-content itself has a definite height (flex: 1 of the 100vh shell).
 .main-content {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   overflow-y: auto;
   background: transparent;
+
+  > *:not(app-footer) {
+    flex-shrink: 0;
+  }
 }
 
 // ── PRO badge & upgrade link ──────────────────────

--- a/src/app/jobs/job-list/job-list.component.ts
+++ b/src/app/jobs/job-list/job-list.component.ts
@@ -167,7 +167,8 @@ export class JobListComponent implements OnInit {
     this.pageIndex = event.pageIndex;
     this.pageSize = event.pageSize;
     this.loadJobs();
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    // The app shell scrolls inside .main-content, not the window
+    document.querySelector('.main-content')?.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   clearFilters(): void {


### PR DESCRIPTION
## Summary
- The footer sat **outside** the scrolling `.main-content` region, so it was permanently pinned on screen and consumed viewport height on every page
- Moved it **inside** the scroll region: on long pages it sits after the content, below the fold, reached by scrolling; on short pages flex + the footer's existing `margin-top: auto` keep it anchored to the bottom edge (no floating mid-screen)
- Routed components keep their bounded heights (`flex-shrink: 0` on non-footer children), so chat (`height: 100%`) and auth page layouts are unaffected
- Bonus fix: job-list pagination "scroll to top" targeted `window`, which never scrolls in this shell — now scrolls `.main-content` (was a silent no-op)

## Testing
- `npm run lint` — 0 errors (587 pre-existing migration warnings)
- `npm run build` — passes
- Worth eyeballing on the dev server before merge: jobs list (long page → footer below fold), login (short page → footer at bottom edge), messages (chat pane height unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)